### PR TITLE
Fix refusal to field message

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
@@ -28,7 +28,13 @@ public class RefusalReceiver {
   @ServiceActivator(inputChannel = "refusalInputChannel")
   public void receiveMessage(ResponseManagementEvent event) {
     if (event.getEvent().getType() != EventType.REFUSAL_RECEIVED) {
-      throw new RuntimeException(); // Unexpected event type
+      throw new RuntimeException(
+          String.format("Event Type '%s' is invalid!", event.getEvent().getType()));
+    }
+
+    // Do not send refusal back to Field if from Field
+    if ("FIELD".equalsIgnoreCase(event.getEvent().getChannel())) {
+      return;
     }
 
     ActionCancel actionCancel = new ActionCancel();

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverIT.java
@@ -60,6 +60,7 @@ public class ActionFieldReceiverIT {
     rabbitQueueHelper.sendMessage(actionFieldQueue, fieldworkFollowup);
 
     String actualMessage = rabbitQueueHelper.getMessage(outboundQueue);
+    assertThat(actualMessage).isNotNull();
     JAXBContext jaxbContext = JAXBContext.newInstance(ActionInstruction.class);
     Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
     StringReader reader = new StringReader(actualMessage);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.jeasy.random.EasyRandom;
 import org.junit.Test;
@@ -15,16 +16,18 @@ import uk.gov.ons.census.fwmtadapter.model.dto.field.ActionInstruction;
 
 public class RefusalReceiverTest {
 
+  EasyRandom easyRandom = new EasyRandom();
+
   @Test
-  public void testReceiveMessage() {
+  public void testRefusalMessageFromNonFieldChannel() {
     // Given
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
 
     // When
     RefusalReceiver underTest = new RefusalReceiver(rabbitTemplate, "TEST EXCHANGE");
-    EasyRandom easyRandom = new EasyRandom();
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getEvent().setType(EventType.REFUSAL_RECEIVED);
+    event.getEvent().setChannel("CC");
     underTest.receiveMessage(event);
 
     // Then
@@ -35,5 +38,21 @@ public class RefusalReceiverTest {
     assertThat(event.getPayload().getRefusal().getCollectionCase().getId())
         .isEqualTo(actionInstruction.getActionCancel().getCaseId());
     assertThat("REFUSED").isEqualTo(actionInstruction.getActionCancel().getReason());
+  }
+
+  @Test
+  public void testRefusalMessageFromFieldChannel() {
+    // Given
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+
+    // When
+    RefusalReceiver underTest = new RefusalReceiver(rabbitTemplate, "TEST EXCHANGE");
+    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
+    event.getEvent().setType(EventType.REFUSAL_RECEIVED);
+    event.getEvent().setChannel("FIELD");
+    underTest.receiveMessage(event);
+
+    // Then
+    verifyZeroInteractions(rabbitTemplate);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
@@ -55,4 +55,24 @@ public class RefusalReceiverTest {
     // Then
     verifyZeroInteractions(rabbitTemplate);
   }
+
+  @Test(expected = RuntimeException.class)
+  public void shouldThrowRuntimeExceptionWhenInvalidEventTypeExpected() {
+    // Given
+    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
+    RefusalReceiver underTest = new RefusalReceiver(rabbitTemplate, "TEST EXCHANGE");
+    ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
+    event.getEvent().setType(EventType.CASE_CREATED);
+    String expectedErrorMessage =
+        String.format("Event Type '%s' is invalid!", EventType.CASE_CREATED);
+
+    try {
+      // When
+      underTest.receiveMessage(event);
+    } catch (RuntimeException re) {
+      // Then
+      assertThat(re.getMessage()).isEqualTo(expectedErrorMessage);
+      throw re;
+    }
+  }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/util/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/util/RabbitQueueHelper.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.census.fwmtadapter.util;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -61,8 +59,6 @@ public class RabbitQueueHelper {
   }
 
   public String getMessage(BlockingQueue<String> queue) throws InterruptedException {
-    String actualMessage = queue.poll(20, TimeUnit.SECONDS);
-    assertNotNull("Did not receive message before timeout", actualMessage);
-    return actualMessage;
+    return queue.poll(20, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
# Motivation and Context
Refusal notifications sent from FWMT should not be sent back
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Refusal notifications are filtered out to FWMT by channel
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
checkout this branch and build local docker image.
run using docker-dev
run tests
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Trello](https://trello.com/c/jHFIWB9G/1002-refusals-from-field-not-being-filtered-out)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):