### PR TITLE
1042 fix action cancel message

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
@@ -3,6 +3,8 @@ package uk.gov.ons.census.fwmtadapter.client;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.census.fwmtadapter.model.dto.CaseContainer;
 import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 
@@ -21,13 +23,23 @@ public class CaseClient {
   }
 
   public CaseContainer getCaseFromCaseId(String caseId) {
-    String url = "http://" + host + ":" + port + "/cases/" + caseId;
-    System.out.println("Attempting to call: " + url);
-    return restTemplate.getForObject(url, CaseContainer.class);
+    UriComponents uriComponents = createUriComponents("/cases/", "caseId", caseId);
+    return restTemplate.getForObject(uriComponents.toUri().toString(), CaseContainer.class);
   }
 
   public CaseIdAddressTypeDto getCaseIdAndAddressTypeFromQid(String questionnaire_id) {
-    String url = "http://" + host + ":" + port + "/cases/qid/" + questionnaire_id;
-    return restTemplate.getForObject(url, CaseIdAddressTypeDto.class);
+    UriComponents uriComponents = createUriComponents("/cases/qid/", "qid", questionnaire_id);
+    return restTemplate.getForObject(uriComponents.toUri().toString(), CaseIdAddressTypeDto.class);
+  }
+
+  private UriComponents createUriComponents(String path, String param_name, String param) {
+    return UriComponentsBuilder.newInstance()
+        .scheme("http")
+        .host(host)
+        .port(port)
+        .path(path)
+        .queryParam(param_name, param)
+        .build()
+        .encode();
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
@@ -23,23 +23,21 @@ public class CaseClient {
   }
 
   public CaseContainer getCaseFromCaseId(String caseId) {
-    UriComponents uriComponents = createUriComponents("/cases/", "caseId", caseId);
+    UriComponents uriComponents = createUriComponents("/cases/{caseId}", caseId);
     return restTemplate.getForObject(uriComponents.toUri().toString(), CaseContainer.class);
   }
 
   public CaseIdAddressTypeDto getCaseIdAndAddressTypeFromQid(String questionnaire_id) {
-    UriComponents uriComponents = createUriComponents("/cases/qid/", "qid", questionnaire_id);
+    UriComponents uriComponents = createUriComponents("/cases/qid/{qid}", questionnaire_id);
     return restTemplate.getForObject(uriComponents.toUri().toString(), CaseIdAddressTypeDto.class);
   }
 
-  private UriComponents createUriComponents(String path, String param_name, String param) {
+  private UriComponents createUriComponents(String path, String id) {
     return UriComponentsBuilder.newInstance()
         .scheme("http")
         .host(host)
         .port(port)
         .path(path)
-        .queryParam(param_name, param)
-        .build()
-        .encode();
+        .buildAndExpand(id);
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
@@ -21,7 +21,8 @@ public class CaseClient {
   }
 
   public CaseContainer getCaseFromCaseId(String caseId) {
-    String url = "http://" + host + ":" + port + "/" + caseId;
+    String url = "http://" + host + ":" + port + "/cases/" + caseId;
+    System.out.println("Attempting to call: " + url);
     return restTemplate.getForObject(url, CaseContainer.class);
   }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/client/CaseClient.java
@@ -2,9 +2,9 @@ package uk.gov.ons.census.fwmtadapter.client;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdDto;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseContainer;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 
 @Component
 public class CaseClient {
@@ -20,17 +20,13 @@ public class CaseClient {
     this.restTemplate = restTemplate;
   }
 
-  public String getCaseIdFromQid(String questionnaire_id) {
+  public CaseContainer getCaseFromCaseId(String caseId) {
+    String url = "http://" + host + ":" + port + "/" + caseId;
+    return restTemplate.getForObject(url, CaseContainer.class);
+  }
+
+  public CaseIdAddressTypeDto getCaseIdAndAddressTypeFromQid(String questionnaire_id) {
     String url = "http://" + host + ":" + port + "/cases/qid/" + questionnaire_id;
-
-    CaseIdDto caseIdDto = restTemplate.getForObject(url, CaseIdDto.class);
-
-    String caseId = caseIdDto.getCaseId();
-
-    if (StringUtils.isEmpty(caseId)) {
-      throw new RuntimeException("Returned empty caseID from case api");
-    }
-
-    return caseIdDto.getCaseId();
+    return restTemplate.getForObject(url, CaseIdAddressTypeDto.class);
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainer.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainer.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.fwmtadapter.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
+import java.util.List;
 import lombok.Data;
 
 @Data
@@ -56,4 +57,6 @@ public class CaseContainer {
   private String lad;
 
   private String state;
+
+  private List<EventDTO> caseEvents;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainer.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainer.java
@@ -1,0 +1,59 @@
+package uk.gov.ons.census.fwmtadapter.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+public class CaseContainer {
+
+  private String caseRef;
+
+  @JsonProperty("id")
+  private String caseId;
+
+  private String arid;
+
+  private String estabArid;
+
+  private String estabType;
+
+  private String uprn;
+
+  @JsonProperty("caseType")
+  private String addressType;
+
+  private OffsetDateTime createdDateTime;
+
+  private String addressLine1;
+
+  private String addressLine2;
+
+  private String addressLine3;
+
+  private String townName;
+
+  private String postcode;
+
+  private String organisationName;
+
+  private String addressLevel;
+
+  private String abpCode;
+
+  private String region;
+
+  private String latitude;
+
+  private String longitude;
+
+  private String oa;
+
+  private String lsoa;
+
+  private String msoa;
+
+  private String lad;
+
+  private String state;
+}

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseIdAddressTypeDto.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseIdAddressTypeDto.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.fwmtadapter.model.dto;
 import lombok.Data;
 
 @Data
-public class CaseIdDto {
+public class CaseIdAddressTypeDto {
   private String caseId;
+  private String addressType;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/EventDTO.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/EventDTO.java
@@ -1,0 +1,19 @@
+package uk.gov.ons.census.fwmtadapter.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+public class EventDTO {
+
+  private String id;
+
+  private String eventType;
+
+  @JsonProperty("description")
+  private String eventDescription;
+
+  @JsonProperty("createdDateTime")
+  private OffsetDateTime eventDate;
+}

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/field/ActionCancel.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/field/ActionCancel.java
@@ -10,39 +10,15 @@ package uk.gov.ons.census.fwmtadapter.model.dto.field;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import lombok.Data;
 
-/**
- * Java class for ActionCancel complex type.
- *
- * <p>The following schema fragment specifies the expected content contained within this class.
- *
- * <pre>
- * &lt;complexType name="ActionCancel"&gt;
- *   &lt;complexContent&gt;
- *     &lt;extension base="{http://ons.gov.uk/ctp/response/action/message/instruction}Action"&gt;
- *       &lt;sequence&gt;
- *         &lt;element name="reason" type="{http://www.w3.org/2001/XMLSchema}string"/&gt;
- *         &lt;element name="caseId" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/&gt;
- *         &lt;element name="caseRef" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/&gt;
- *       &lt;/sequence&gt;
- *     &lt;/extension&gt;
- *   &lt;/complexContent&gt;
- * &lt;/complexType&gt;
- * </pre>
- */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(
     name = "ActionCancel",
-    propOrder = {"reason", "caseId", "caseRef"})
+    propOrder = {"caseId", "addressType"})
 @Data
 public class ActionCancel extends Action {
-
-  @XmlElement(required = true)
-  protected String reason;
-
   protected String caseId;
-  protected String caseRef;
+  protected String addressType;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/services/ReceiptService.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/services/ReceiptService.java
@@ -29,8 +29,6 @@ public class ReceiptService {
   public void processReceipt(ResponseManagementEvent receiptEvent) {
     ActionCancel actionCancel = new ActionCancel();
 
-    String a = receiptEvent.getPayload().getReceipt().getQuestionnaireId();
-
     CaseIdAddressTypeDto caseIdAddressType =
         caseClient.getCaseIdAndAddressTypeFromQid(
             receiptEvent.getPayload().getReceipt().getQuestionnaireId());

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -8,6 +8,8 @@ import org.jeasy.random.EasyRandom;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.census.fwmtadapter.model.dto.CaseContainer;
 import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 
@@ -24,14 +26,14 @@ public class CaseClientTest {
 
   @Test
   public void successfulyGetCaseIdFromQid() {
-    String expectedUrl = "http://" + host + ":" + port + "/cases/qid/" + QUESTIONAIRE_ID;
+    UriComponents expectedUri = createUriComponents("/cases/qid/", "qid", QUESTIONAIRE_ID);
 
     CaseIdAddressTypeDto expectedCaseIdAddressTypeDto = new CaseIdAddressTypeDto();
     expectedCaseIdAddressTypeDto.setCaseId(CASE_ID);
     expectedCaseIdAddressTypeDto.setAddressType(ADDRESS_TYPE_TEST);
 
     RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.getForObject(expectedUrl, CaseIdAddressTypeDto.class))
+    when(restTemplate.getForObject(expectedUri.toUri().toString(), CaseIdAddressTypeDto.class))
         .thenReturn(expectedCaseIdAddressTypeDto);
 
     CaseClient caseClient = new CaseClient(restTemplate);
@@ -42,17 +44,29 @@ public class CaseClientTest {
 
   @Test
   public void successfullyGetCaseByCaseId() {
-    String expectedUrl = "http://" + host + ":" + port + "/cases/" + CASE_ID;
+    UriComponents expectedUri = createUriComponents("/cases/", "caseId", CASE_ID);
     EasyRandom easyRandom = new EasyRandom();
 
     CaseContainer caseContainer = easyRandom.nextObject(CaseContainer.class);
     caseContainer.setCaseId(CASE_ID);
 
     RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.getForObject(expectedUrl, CaseContainer.class)).thenReturn(caseContainer);
+    when(restTemplate.getForObject(expectedUri.toUri().toString(), CaseContainer.class))
+        .thenReturn(caseContainer);
 
     CaseClient caseClient = new CaseClient(restTemplate);
 
     assertThat(caseClient.getCaseFromCaseId(CASE_ID)).isEqualTo(caseContainer);
+  }
+
+  private UriComponents createUriComponents(String path, String param_name, String param) {
+    return UriComponentsBuilder.newInstance()
+        .scheme("http")
+        .host(host)
+        .port(port)
+        .path(path)
+        .queryParam(param_name, param)
+        .build()
+        .encode();
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -26,7 +26,7 @@ public class CaseClientTest {
 
   @Test
   public void successfulyGetCaseIdFromQid() {
-    UriComponents expectedUri = createUriComponents("/cases/qid/", "qid", QUESTIONAIRE_ID);
+    UriComponents expectedUri = createUriComponents("/cases/qid/{qid}", QUESTIONAIRE_ID);
 
     CaseIdAddressTypeDto expectedCaseIdAddressTypeDto = new CaseIdAddressTypeDto();
     expectedCaseIdAddressTypeDto.setCaseId(CASE_ID);
@@ -44,7 +44,7 @@ public class CaseClientTest {
 
   @Test
   public void successfullyGetCaseByCaseId() {
-    UriComponents expectedUri = createUriComponents("/cases/", "caseId", CASE_ID);
+    UriComponents expectedUri = createUriComponents("/cases/{caseId}", CASE_ID);
     EasyRandom easyRandom = new EasyRandom();
 
     CaseContainer caseContainer = easyRandom.nextObject(CaseContainer.class);
@@ -59,14 +59,12 @@ public class CaseClientTest {
     assertThat(caseClient.getCaseFromCaseId(CASE_ID)).isEqualTo(caseContainer);
   }
 
-  private UriComponents createUriComponents(String path, String param_name, String param) {
+  private UriComponents createUriComponents(String path, String id) {
     return UriComponentsBuilder.newInstance()
-        .scheme("http")
-        .host(host)
-        .port(port)
-        .path(path)
-        .queryParam(param_name, param)
-        .build()
-        .encode();
+            .scheme("http")
+            .host(host)
+            .port(port)
+            .path(path)
+            .buildAndExpand(id);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -4,14 +4,17 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.jeasy.random.EasyRandom;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdDto;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseContainer;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 
 public class CaseClientTest {
   private static final String QUESTIONAIRE_ID = "123a";
   private static final String CASE_ID = "g5dv3";
+  public static final String ADDRESS_TYPE_TEST = "address_type_test";
 
   @Value("${caseapi.host}")
   private String host;
@@ -23,28 +26,33 @@ public class CaseClientTest {
   public void successfulyGetCaseIdFromQid() {
     String expectedUrl = "http://" + host + ":" + port + "/cases/qid/" + QUESTIONAIRE_ID;
 
-    CaseIdDto expectedCaseIdDto = new CaseIdDto();
-    expectedCaseIdDto.setCaseId(CASE_ID);
+    CaseIdAddressTypeDto expectedCaseIdAddressTypeDto = new CaseIdAddressTypeDto();
+    expectedCaseIdAddressTypeDto.setCaseId(CASE_ID);
+    expectedCaseIdAddressTypeDto.setAddressType(ADDRESS_TYPE_TEST);
 
     RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.getForObject(expectedUrl, CaseIdDto.class)).thenReturn(expectedCaseIdDto);
+    when(restTemplate.getForObject(expectedUrl, CaseIdAddressTypeDto.class))
+        .thenReturn(expectedCaseIdAddressTypeDto);
 
     CaseClient caseClient = new CaseClient(restTemplate);
 
-    assertThat(caseClient.getCaseIdFromQid(QUESTIONAIRE_ID)).isEqualTo(CASE_ID);
+    assertThat(caseClient.getCaseIdAndAddressTypeFromQid(QUESTIONAIRE_ID))
+        .isEqualTo(expectedCaseIdAddressTypeDto);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testNullCaseIdReturned() {
-    String expectedUrl = "http://" + host + ":" + port + "/cases/qid/" + QUESTIONAIRE_ID;
+  @Test
+  public void successfullyGetCaseByCaseId() {
+    String expectedUrl = "http://" + host + ":" + port + "/" + CASE_ID;
+    EasyRandom easyRandom = new EasyRandom();
 
-    CaseIdDto expectedCaseIdDto = new CaseIdDto();
+    CaseContainer caseContainer = easyRandom.nextObject(CaseContainer.class);
+    caseContainer.setCaseId(CASE_ID);
 
     RestTemplate restTemplate = mock(RestTemplate.class);
-    when(restTemplate.getForObject(expectedUrl, CaseIdDto.class)).thenReturn(expectedCaseIdDto);
+    when(restTemplate.getForObject(expectedUrl, CaseContainer.class)).thenReturn(caseContainer);
 
     CaseClient caseClient = new CaseClient(restTemplate);
 
-    caseClient.getCaseIdFromQid(QUESTIONAIRE_ID);
+    assertThat(caseClient.getCaseFromCaseId(CASE_ID)).isEqualTo(caseContainer);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -16,7 +16,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 public class CaseClientTest {
   private static final String QUESTIONAIRE_ID = "123a";
   private static final String CASE_ID = "g5dv3";
-  public static final String ADDRESS_TYPE_TEST = "address_type_test";
+  private static final String ADDRESS_TYPE_TEST = "address_type_test";
 
   @Value("${caseapi.host}")
   private String host;

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -42,7 +42,7 @@ public class CaseClientTest {
 
   @Test
   public void successfullyGetCaseByCaseId() {
-    String expectedUrl = "http://" + host + ":" + port + "/" + CASE_ID;
+    String expectedUrl = "http://" + host + ":" + port + "/cases/" + CASE_ID;
     EasyRandom easyRandom = new EasyRandom();
 
     CaseContainer caseContainer = easyRandom.nextObject(CaseContainer.class);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/client/CaseClientTest.java
@@ -61,10 +61,10 @@ public class CaseClientTest {
 
   private UriComponents createUriComponents(String path, String id) {
     return UriComponentsBuilder.newInstance()
-            .scheme("http")
-            .host(host)
-            .port(port)
-            .path(path)
-            .buildAndExpand(id);
+        .scheme("http")
+        .host(host)
+        .port(port)
+        .path(path)
+        .buildAndExpand(id);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ReceiptReceiverIT.java
@@ -71,7 +71,7 @@ public class ReceiptReceiverIT {
   public void testGoodReceiptMessage()
       throws InterruptedException, JAXBException, JsonProcessingException {
     // Given
-    String url = "/cases/qid/" + TEST_QID;
+    String url = "/cases/qid/?qid=" + TEST_QID;
     CaseIdAddressTypeDto caseIdAddressTypeDto = new CaseIdAddressTypeDto();
     caseIdAddressTypeDto.setCaseId(TEST_CASE_ID);
     caseIdAddressTypeDto.setAddressType(TEST_ADDRESS_TYPE);
@@ -115,7 +115,7 @@ public class ReceiptReceiverIT {
     receiptDTO.setQuestionnaireId(TEST_QID);
     ResponseManagementEvent responseManagementEvent =
         setUpResponseManagementReceiptEvent(receiptDTO);
-    String url = "/cases/qid/" + TEST_QID;
+    String url = "/cases/qid/?qid=" + TEST_QID;
 
     stubFor(get(urlEqualTo(url)).willReturn(aResponse().withStatus(HttpStatus.NOT_FOUND.value())));
 

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ReceiptReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ReceiptReceiverIT.java
@@ -71,7 +71,7 @@ public class ReceiptReceiverIT {
   public void testGoodReceiptMessage()
       throws InterruptedException, JAXBException, JsonProcessingException {
     // Given
-    String url = "/cases/qid/?qid=" + TEST_QID;
+    String url = "/cases/qid/" + TEST_QID;
     CaseIdAddressTypeDto caseIdAddressTypeDto = new CaseIdAddressTypeDto();
     caseIdAddressTypeDto.setCaseId(TEST_CASE_ID);
     caseIdAddressTypeDto.setAddressType(TEST_ADDRESS_TYPE);
@@ -115,7 +115,7 @@ public class ReceiptReceiverIT {
     receiptDTO.setQuestionnaireId(TEST_QID);
     ResponseManagementEvent responseManagementEvent =
         setUpResponseManagementReceiptEvent(receiptDTO);
-    String url = "/cases/qid/?qid=" + TEST_QID;
+    String url = "/cases/qid/" + TEST_QID;
 
     stubFor(get(urlEqualTo(url)).willReturn(aResponse().withStatus(HttpStatus.NOT_FOUND.value())));
 

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -43,8 +43,8 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RefusalReceiverIT {
-  public static final String TEST_CASE_ID = "test_case_id";
-  public static final String TEST_ADDRESS_TYPE = "test_address_type";
+  private static final String TEST_CASE_ID = "test_case_id";
+  private static final String TEST_ADDRESS_TYPE = "test_address_type";
 
   @Value("${queueconfig.case-event-exchange}")
   private String caseEventExchange;
@@ -60,8 +60,8 @@ public class RefusalReceiverIT {
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 
-  private EasyRandom easyRandom = new EasyRandom();
-  private ObjectMapper objectMapper = new ObjectMapper();
+  private final EasyRandom easyRandom = new EasyRandom();
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Rule
   public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -91,7 +91,7 @@ public class RefusalReceiverIT {
     event.setType(EventType.REFUSAL_RECEIVED);
     responseManagementEvent.setEvent(event);
 
-    String url = "/cases/?caseId=" + TEST_CASE_ID;
+    String url = "/cases/" + TEST_CASE_ID;
     CaseContainer caseContainer = new CaseContainer();
     caseContainer.setAddressType(TEST_ADDRESS_TYPE);
     String returnJson = objectMapper.writeValueAsString(caseContainer);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -91,7 +91,7 @@ public class RefusalReceiverIT {
     event.setType(EventType.REFUSAL_RECEIVED);
     responseManagementEvent.setEvent(event);
 
-    String url = "/" + TEST_CASE_ID;
+    String url = "/cases/" + TEST_CASE_ID;
     CaseContainer caseContainer = new CaseContainer();
     caseContainer.setAddressType(TEST_ADDRESS_TYPE);
     String returnJson = objectMapper.writeValueAsString(caseContainer);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -1,7 +1,13 @@
 package uk.gov.ons.census.fwmtadapter.messaging;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.StringReader;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
@@ -9,16 +15,19 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import org.jeasy.random.EasyRandom;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseContainer;
 import uk.gov.ons.census.fwmtadapter.model.dto.CollectionCase;
 import uk.gov.ons.census.fwmtadapter.model.dto.Event;
 import uk.gov.ons.census.fwmtadapter.model.dto.EventType;
@@ -34,6 +43,9 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RefusalReceiverIT {
+  public static final String TEST_CASE_ID = "test_case_id";
+  public static final String TEST_ADDRESS_TYPE = "test_address_type";
+
   @Value("${queueconfig.case-event-exchange}")
   private String caseEventExchange;
 
@@ -49,6 +61,10 @@ public class RefusalReceiverIT {
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 
   private EasyRandom easyRandom = new EasyRandom();
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
 
   @Before
   @Transactional
@@ -59,12 +75,12 @@ public class RefusalReceiverIT {
 
   @Test
   public void testRefusalMessageFromNonFieldChannelEmitsMessageToField()
-      throws InterruptedException, JAXBException {
+      throws InterruptedException, JAXBException, JsonProcessingException {
     // Given
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(actionOutboundQueue);
 
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("123");
+    collectionCase.setId(TEST_CASE_ID);
     Refusal refusal = new Refusal();
     refusal.setCollectionCase(collectionCase);
     Payload payload = new Payload();
@@ -74,6 +90,19 @@ public class RefusalReceiverIT {
     Event event = new Event();
     event.setType(EventType.REFUSAL_RECEIVED);
     responseManagementEvent.setEvent(event);
+
+    String url = "/" + TEST_CASE_ID;
+    CaseContainer caseContainer = new CaseContainer();
+    caseContainer.setAddressType(TEST_ADDRESS_TYPE);
+    String returnJson = objectMapper.writeValueAsString(caseContainer);
+
+    stubFor(
+        get(urlEqualTo(url))
+            .willReturn(
+                aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(returnJson)));
 
     rabbitQueueHelper.sendMessage(caseEventExchange, refusalRoutingKey, responseManagementEvent);
 
@@ -86,7 +115,7 @@ public class RefusalReceiverIT {
     ActionInstruction actionInstruction = (ActionInstruction) unmarshaller.unmarshal(reader);
     assertThat(responseManagementEvent.getPayload().getRefusal().getCollectionCase().getId())
         .isEqualTo(actionInstruction.getActionCancel().getCaseId());
-    assertThat("REFUSED").isEqualTo(actionInstruction.getActionCancel().getReason());
+    assertThat(actionInstruction.getActionCancel().getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -91,7 +91,7 @@ public class RefusalReceiverIT {
     event.setType(EventType.REFUSAL_RECEIVED);
     responseManagementEvent.setEvent(event);
 
-    String url = "/cases/" + TEST_CASE_ID;
+    String url = "/cases/?caseId=" + TEST_CASE_ID;
     CaseContainer caseContainer = new CaseContainer();
     caseContainer.setAddressType(TEST_ADDRESS_TYPE);
     String returnJson = objectMapper.writeValueAsString(caseContainer);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/services/ReceiptServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/services/ReceiptServiceTest.java
@@ -3,51 +3,35 @@ package uk.gov.ons.census.fwmtadapter.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static uk.gov.ons.census.fwmtadapter.services.ReceiptService.RECEIPTED;
 import static uk.gov.ons.census.fwmtadapter.util.ReceiptHelper.setUpResponseManagementReceiptEvent;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.gov.ons.census.fwmtadapter.client.CaseClient;
+import uk.gov.ons.census.fwmtadapter.model.dto.CaseIdAddressTypeDto;
 import uk.gov.ons.census.fwmtadapter.model.dto.ReceiptDTO;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.field.ActionInstruction;
 
 public class ReceiptServiceTest {
-
   private static final String TEST_CASE_ID = "test_case_id";
   private static final String TEST_QID = "test_qid";
+  private static final String TEST_ADDRESS_TYPE = "test address type";
 
   @Test
-  public void testReceiptWithCaseId() {
-    // Given
-    ReceiptDTO receiptDTO = new ReceiptDTO();
-    receiptDTO.setCaseId(TEST_CASE_ID);
-    RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
-    ResponseManagementEvent responseManagementEvent =
-        setUpResponseManagementReceiptEvent(receiptDTO);
-    ReceiptService receiptService = new ReceiptService(rabbitTemplate, "exchange_name", null);
-
-    // When
-    receiptService.processReceipt(responseManagementEvent);
-
-    // then
-    ArgumentCaptor<ActionInstruction> argCaptor = ArgumentCaptor.forClass(ActionInstruction.class);
-    verify(rabbitTemplate).convertAndSend(eq("exchange_name"), eq(""), argCaptor.capture());
-    ActionInstruction actionInstruction = argCaptor.getValue();
-    assertThat(actionInstruction.getActionCancel().getCaseId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actionInstruction.getActionCancel().getReason()).isEqualTo(RECEIPTED);
-  }
-
-  @Test
-  public void testReceiptWithQidAndNoCaseId() {
+  public void testReceipt() {
     // Given
     ReceiptDTO receiptDTO = new ReceiptDTO();
     receiptDTO.setQuestionnaireId(TEST_QID);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     CaseClient caseClient = mock(CaseClient.class);
-    when(caseClient.getCaseIdFromQid(TEST_QID)).thenReturn(TEST_CASE_ID);
+
+    CaseIdAddressTypeDto caseIdAddressTypeDto = new CaseIdAddressTypeDto();
+    caseIdAddressTypeDto.setCaseId(TEST_CASE_ID);
+    caseIdAddressTypeDto.setAddressType(TEST_ADDRESS_TYPE);
+
+    when(caseClient.getCaseIdAndAddressTypeFromQid(TEST_QID)).thenReturn(caseIdAddressTypeDto);
 
     ResponseManagementEvent responseManagementEvent =
         setUpResponseManagementReceiptEvent(receiptDTO);
@@ -60,7 +44,7 @@ public class ReceiptServiceTest {
     verify(rabbitTemplate).convertAndSend(eq("exchange_name"), eq(""), argCaptor.capture());
     ActionInstruction actionInstruction = argCaptor.getValue();
     assertThat(actionInstruction.getActionCancel().getCaseId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actionInstruction.getActionCancel().getReason()).isEqualTo(RECEIPTED);
+    assertThat(actionInstruction.getActionCancel().getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);
   }
 
   @Test(expected = RuntimeException.class)
@@ -69,7 +53,7 @@ public class ReceiptServiceTest {
     receiptDTO.setQuestionnaireId(TEST_QID);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     CaseClient caseClient = mock(CaseClient.class);
-    when(caseClient.getCaseIdFromQid(TEST_QID)).thenThrow(new RuntimeException());
+    when(caseClient.getCaseIdAndAddressTypeFromQid(TEST_QID)).thenThrow(new RuntimeException());
 
     ResponseManagementEvent responseManagementEvent =
         setUpResponseManagementReceiptEvent(receiptDTO);


### PR DESCRIPTION
# Motivation and Context
ActionCancel msg was missing addressType

# What has changed
Added AddressType to ActionCancel msg
This requires extra/different calls to case-api

# How to test?
Get the related ATs and case-api 
https://github.com/ONSdigital/census-rm-case-api/pull/23
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/104


# Links
https://trello.com/c/B7P71yDJ/1042-cancel-refusal-message-to-the-field-is-incorrect