### PR TITLE
Fix for strict JSON checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-slim
+FROM openjdk:11-jdk-slim
 
 ARG JAR_FILE=census-rm-fieldwork-adapter*.jar
 COPY target/$JAR_FILE /opt/census-rm-fieldwork-adapter.jar

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageErrorHandler.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageErrorHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmtadapter.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -27,6 +28,7 @@ public class MessageErrorHandler implements ErrorHandler {
     objectMapper = new ObjectMapper();
     objectMapper.registerModule(new JavaTimeModule());
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     try {
       digest = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageErrorHandler.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageErrorHandler.java
@@ -50,22 +50,15 @@ public class MessageErrorHandler implements ErrorHandler {
       String messageHash = bytesToHexString(digest.digest(rawMessageBody));
 
       log.with("message_hash", messageHash)
+          .with("valid_json", validateJson(messageBody))
           .with("cause", failedException.getCause().getMessage())
           .error("Could not process message");
-
-      try {
-        objectMapper.readValue(messageBody, expectedType);
-      } catch (IOException e) {
-        log.with("message_hash", messageHash)
-            .with("cause", e.getMessage())
-            .error("Could not deserialise. JSON not in expected format or invalid");
-      }
     } else {
       log.error("Unexpected exception has occurred", throwable);
     }
   }
 
-  private static String bytesToHexString(byte[] hash) {
+  private String bytesToHexString(byte[] hash) {
     StringBuffer hexString = new StringBuffer();
     for (int i = 0; i < hash.length; i++) {
       String hex = Integer.toHexString(0xff & hash[i]);
@@ -73,5 +66,14 @@ public class MessageErrorHandler implements ErrorHandler {
       hexString.append(hex);
     }
     return hexString.toString();
+  }
+
+  private String validateJson(String messageBody) {
+    try {
+      objectMapper.readValue(messageBody, expectedType);
+      return "Valid JSON";
+    } catch (IOException e) {
+      return String.format("Invalid JSON: %s", e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
# Motivation and Context
We can't handle messages from FWMT due to strict JSON checking

# What has changed
Disabled strict JSON checking.

# How to test?
Hard to reproduce, but try this message:
```
{"event":{"type":"FULFILMENT_REQUESTED","source":"FIELDWORK_GATEWAY","channel":"FIELD","dateTime":"2019-09-13T14:22:34.327Z","transactionId":"3287c518-1898-406c-b55e-1e6138678550"},"payload":{"fulfilmentRequest":{"fulfilmentCode":"P_OR_H1","caseId":"02606dca-7f75-e911-abc4-0003ff39541c","address":{},"contact":{"title":null,"forename":null,"surname":null,"telNo":null}}}}
```

# Links
Trello: https://trello.com/c/MKGPgxP8