### PR TITLE
Making dockerfile non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM openjdk:11-jdk-slim
 
 ARG JAR_FILE=census-rm-fieldwork-adapter*.jar
-COPY target/$JAR_FILE /opt/census-rm-fieldwork-adapter.jar
+CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/census-rm-fieldwork-adapter.jar"]
 
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN chmod +x /opt/healthcheck.sh
 
-CMD exec /usr/local/openjdk-11/bin/java $JAVA_OPTS -jar /opt/census-rm-fieldwork-adapter.jar
+RUN groupadd --gid 999 fieldworkadapter && \
+    useradd --create-home --system --uid 999 --gid fieldworkadapter fieldworkadapter
+USER fieldworkadapter
+
+COPY target/$JAR_FILE /opt/census-rm-fieldwork-adapter.jar


### PR DESCRIPTION
# Motivation and Context
Running docker containers in root is a security concern so there should be a user that's created that the container can use instead. 

# What has changed
- Added a non-root user
- Updated dockerfile layout
- Removed JAVA_OPTS instead pass in JAVA_TOOL_OPTIONS in compose and kubernetes 
# How to test?
- Run mvn clean install
- Run in docker dev environment with other prs
- Run in kubernetes environment with other prs

# Links
[Trello](https://trello.com/c/dUT7y0TW)