### PR TITLE
Rabbit msg persistence dlq config

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
@@ -36,9 +36,6 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
 
-  @Value("${queueconfig.retry-exchange}")
-  private String retryExchange;
-
   @Value("${queueconfig.quarantine-exchange}")
   private String quarantineExchange;
 
@@ -152,7 +149,6 @@ public class MessageConsumerConfig {
             logStackTraces,
             "Fieldwork Adapter",
             queueName,
-            retryExchange,
             quarantineExchange,
             rabbitTemplate);
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ManagedMessageRecoverer.java
@@ -8,6 +8,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -18,6 +19,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.ExceptionReportResponse;
 import uk.gov.ons.census.fwmtadapter.model.dto.SkippedMessage;
 
 public class ManagedMessageRecoverer implements MessageRecoverer {
+
   private static final Logger log = LoggerFactory.getLogger(ManagedMessageRecoverer.class);
   private static final ObjectMapper objectMapper;
   private static final MessageDigest digest;
@@ -40,7 +42,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
   private final boolean logStackTraces;
   private final String serviceName;
   private final String queueName;
-  private final String delayExchangeName;
   private final String quarantineExchangeName;
   private final RabbitTemplate rabbitTemplate;
 
@@ -50,7 +51,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       boolean logStackTraces,
       String serviceName,
       String queueName,
-      String delayExchangeName,
       String quarantineExchangeName,
       RabbitTemplate rabbitTemplate) {
     this.exceptionManagerClient = exceptionManagerClient;
@@ -58,7 +58,6 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
     this.logStackTraces = logStackTraces;
     this.serviceName = serviceName;
     this.queueName = queueName;
-    this.delayExchangeName = delayExchangeName;
     this.quarantineExchangeName = quarantineExchangeName;
     this.rabbitTemplate = rabbitTemplate;
   }
@@ -88,10 +87,9 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
       logMessage(
           reportResult, listenerExecutionFailedException.getCause(), messageHash, rawMessageBody);
 
-      // At this point message is not persistent, we need it to be persistent
-      message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
-      // Send the bad message to an exchange where it'll be retried at some future point in time
-      rabbitTemplate.send(delayExchangeName, queueName, message);
+      // Reject the original message where it'll be retried at some future point in time
+      throw new AmqpRejectAndDontRequeueException(
+          String.format("Message sent to DLQ exchange, message_hash is: %s", messageHash));
     } else {
       // Very unlikely that this'd happen but let's log it anyway
       log.error("Unexpected exception has occurred", throwable);
@@ -208,7 +206,9 @@ public class ManagedMessageRecoverer implements MessageRecoverer {
     StringBuffer hexString = new StringBuffer();
     for (int i = 0; i < hash.length; i++) {
       String hex = Integer.toHexString(0xff & hash[i]);
-      if (hex.length() == 1) hexString.append('0');
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
       hexString.append(hex);
     }
     return hexString.toString();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ queueconfig:
   consumers: 50
   retry-attempts: 3
   retry-delay: 1000 #milliseconds
-  retry-exchange: delayedRedeliveryExchange
   quarantine-exchange: quarantineExchange
 
 healthcheck:
@@ -34,3 +33,7 @@ exceptionmanager:
 
 messagelogging:
   logstacktraces: false
+
+logging:
+  level:
+    org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler: ERROR

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ManagedMessageRecovererTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -22,11 +23,13 @@ import uk.gov.ons.census.fwmtadapter.model.dto.ExceptionReportResponse;
 import uk.gov.ons.census.fwmtadapter.model.dto.SkippedMessage;
 
 public class ManagedMessageRecovererTest {
+
   private static final String MESSAGE_HASH =
       "4f1ec3a5f36117da0e9ba42c2eda77dea47b279358a7b2bb538a51d3e13bd229";
 
-  @Test
+  @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecover() {
+    // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
@@ -36,7 +39,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -52,20 +54,24 @@ public class ManagedMessageRecovererTest {
     when(exceptionManagerClient.reportException(any(), any(), any(), any()))
         .thenReturn(exceptionReportResponse);
 
-    underTest.recover(message, failedException);
+    try {
+      // When
+      underTest.recover(message, failedException);
+    } catch (AmqpRejectAndDontRequeueException expectedException) {
+      // Then
+      verify(exceptionManagerClient)
+          .reportException(
+              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
 
-    verify(exceptionManagerClient)
-        .reportException(
-            eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+      verifyNoMoreInteractions(exceptionManagerClient);
 
-    verify(rabbitTemplate).send(eq("test delay exchange"), eq("test queue"), eq(message));
-
-    verifyNoMoreInteractions(exceptionManagerClient);
-    verifyNoMoreInteractions(rabbitTemplate);
+      throw expectedException;
+    }
   }
 
-  @Test
+  @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecoverExceptionManagerUnavailable() {
+    // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
@@ -75,7 +81,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -87,16 +92,19 @@ public class ManagedMessageRecovererTest {
     when(exceptionManagerClient.reportException(any(), any(), any(), any()))
         .thenThrow(new RuntimeException());
 
-    underTest.recover(message, failedException);
+    try {
+      // When
+      underTest.recover(message, failedException);
+    } catch (AmqpRejectAndDontRequeueException expectedException) {
+      // Then
+      verify(exceptionManagerClient)
+          .reportException(
+              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
 
-    verify(exceptionManagerClient)
-        .reportException(
-            eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+      verifyNoMoreInteractions(exceptionManagerClient);
 
-    verify(rabbitTemplate).send(eq("test delay exchange"), eq("test queue"), eq(message));
-
-    verifyNoMoreInteractions(exceptionManagerClient);
-    verifyNoMoreInteractions(rabbitTemplate);
+      throw expectedException;
+    }
   }
 
   @Test
@@ -110,7 +118,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -161,8 +168,9 @@ public class ManagedMessageRecovererTest {
     verifyNoMoreInteractions(rabbitTemplate);
   }
 
-  @Test
+  @Test(expected = AmqpRejectAndDontRequeueException.class)
   public void testRecoverPeek() {
+    // Given
     ExceptionManagerClient exceptionManagerClient = mock(ExceptionManagerClient.class);
     RabbitTemplate rabbitTemplate = mock(RabbitTemplate.class);
     ManagedMessageRecoverer underTest =
@@ -172,7 +180,6 @@ public class ManagedMessageRecovererTest {
             false,
             "test service",
             "test queue",
-            "test delay exchange",
             "test quarantine exchange",
             rabbitTemplate);
 
@@ -192,18 +199,21 @@ public class ManagedMessageRecovererTest {
     when(exceptionManagerClient.reportException(any(), any(), any(), any()))
         .thenReturn(exceptionReportResponse);
 
-    underTest.recover(message, failedException);
+    try {
+      // When
+      underTest.recover(message, failedException);
+    } catch (AmqpRejectAndDontRequeueException expectedException) {
+      // Then
+      verify(exceptionManagerClient)
+          .reportException(
+              eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
 
-    verify(exceptionManagerClient)
-        .reportException(
-            eq(MESSAGE_HASH), eq("test service"), eq("test queue"), eq(cause.getCause()));
+      verify(exceptionManagerClient)
+          .respondToPeek(eq(MESSAGE_HASH), eq("test message body".getBytes()));
 
-    verify(exceptionManagerClient)
-        .respondToPeek(eq(MESSAGE_HASH), eq("test message body".getBytes()));
+      verifyNoMoreInteractions(exceptionManagerClient);
 
-    verify(rabbitTemplate).send(eq("test delay exchange"), eq("test queue"), eq(message));
-
-    verifyNoMoreInteractions(exceptionManagerClient);
-    verifyNoMoreInteractions(rabbitTemplate);
+      throw expectedException;
+    }
   }
 }

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -31,35 +31,60 @@
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "Action.Field"
+      }
     },
     {
       "name": "FieldworkAdapter.Refusals",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "FieldworkAdapter.Refusals"
+      }
     },
     {
       "name": "FieldworkAdapter.uacUpdated",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "FieldworkAdapter.uacUpdated"
+      }
     },
     {
       "name": "RM.Field",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "RM.Field"
+      }
     },
     {
       "name": "FieldworkAdapter.invalidAddress",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-dead-letter-exchange": "delayedRedeliveryExchange",
+        "x-dead-letter-routing-key": "FieldworkAdapter.invalidAddress"
+      }
+    },
+    {
+      "name": "delayedRedeliveryQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-dead-letter-exchange": "",
+        "x-message-ttl": 2000
+      }
     }
   ],
   "exchanges": [
@@ -76,6 +101,15 @@
       "name": "adapter-outbound-exchange",
       "vhost": "/",
       "type": "direct",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {}
+    },
+    {
+      "name": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "type": "headers",
       "durable": true,
       "auto_delete": false,
       "internal": false,
@@ -113,6 +147,14 @@
       "destination": "FieldworkAdapter.uacUpdated",
       "destination_type": "queue",
       "routing_key": "event.uac.update",
+      "arguments": {}
+    },
+    {
+      "source": "delayedRedeliveryExchange",
+      "vhost": "/",
+      "destination": "delayedRedeliveryQueue",
+      "destination_type": "queue",
+      "routing_key": "",
       "arguments": {}
     }
   ]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to make RabbitMQ responsible for routing bad messages to a DLQ instead of manually doing this in our application code. This PR makes use of `AmqpRejectAndDontRequeueException` to reject a bad message, allowing Rabbit to take care of routing and redelivering that message.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Reject the message by throwing an exception
* Remove retry exchange from code 
* Suppress 'noisy' stack trace logging at warning level when the exception is thrown
*  Update tests and test queue config

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build this branch, checkout the [docker-dev PR](https://github.com/ONSdigital/census-rm-docker-dev/pull/40) and post a bad message to a queue this service consumes from. Check the message is redelivered continuously.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hG9Mi8tA/315-rabbit-message-persistence-dlq-config-8