### PR TITLE
Rmc 173 blank questionnaire returned

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiver.java
@@ -34,9 +34,13 @@ public class UacUpdatedReceiver {
   @Transactional
   @ServiceActivator(inputChannel = "uacUpdatedInputChannel")
   public void receiveMessage(ResponseManagementEvent event) {
+    // If the UacQid is still active don't send a Cancel msg to field.
+    // If the UacQid is Unreceipted (BlankQuestionnaire) then don't send a Cancel msg out
     if (event.getPayload().getUac().isActive() || event.getPayload().getUac().isUnreceipted()) {
       return;
-    } else if (StringUtils.isEmpty(event.getPayload().getUac().getCaseId())) {
+    }
+
+    if (StringUtils.isEmpty(event.getPayload().getUac().getCaseId())) {
       log.with("qid", event.getPayload().getUac().getQuestionnaireId())
           .warn("We would like to cancel the associated case but it's not been linked yet");
       return;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiver.java
@@ -34,7 +34,7 @@ public class UacUpdatedReceiver {
   @Transactional
   @ServiceActivator(inputChannel = "uacUpdatedInputChannel")
   public void receiveMessage(ResponseManagementEvent event) {
-    if (event.getPayload().getUac().isActive()) {
+    if (event.getPayload().getUac().isActive() || event.getPayload().getUac().isUnreceipted()) {
       return;
     } else if (StringUtils.isEmpty(event.getPayload().getUac().getCaseId())) {
       log.with("qid", event.getPayload().getUac().getQuestionnaireId())

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Uac.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Uac.java
@@ -12,4 +12,5 @@ public class Uac {
   private String region;
   private String caseId;
   private String collectionExerciseId;
+  private boolean unreceipted;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverTest.java
@@ -85,6 +85,24 @@ public class UacUpdatedReceiverTest {
   }
 
   @Test
+  public void testReceiveMessageUnReceipted() {
+    // Given
+    Uac uac = new Uac();
+    uac.setUnreceipted(true);
+    Payload payload = new Payload();
+    payload.setUac(uac);
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setPayload(payload);
+
+    // When
+    underTest.receiveMessage(responseManagementEvent);
+
+    // Then
+    verify(caseClient, never()).getCaseFromCaseId(any());
+    verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+  }
+
+  @Test
   public void testReceiveMessageUnlinkedUacQid() {
     // Given
     Uac uac = new Uac();


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When we send an action cancel request, we now check to see if the UAC is unreceipted as well as active. If the UAC is unreceipted we don't want to send an action cancel request to field. 

# What has changed
- Added unreceipt field to UAC dto

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

- Run `mvn clean install` and run with other prs and tests

# Links
[Trello](https://trello.com/c/EmrziSj3)
# Screenshots (if appropriate):