### PR TITLE
Ignore cancel msg for continuation QID

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/utility/QuestionnaireTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/utility/QuestionnaireTypeHelper.java
@@ -1,0 +1,30 @@
+package uk.gov.ons.census.fwmtadapter.utility;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class QuestionnaireTypeHelper {
+
+  private static final String ENGLAND_HOUSEHOLD_CONTINUATION = "11";
+  private static final String WALES_HOUSEHOLD_CONTINUATION = "12";
+  private static final String WALES_HOUSEHOLD_CONTINUATION_WELSH = "13";
+  private static final String NORTHERN_IRELAND_HOUSEHOLD_CONTINUATION = "14";
+  private static final String CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES = "61";
+  private static final String CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_WALES_WELSH = "63";
+  private static final Set<String> continuationQuestionnaireTypes =
+      new HashSet<>(
+          Arrays.asList(
+              ENGLAND_HOUSEHOLD_CONTINUATION,
+              WALES_HOUSEHOLD_CONTINUATION,
+              WALES_HOUSEHOLD_CONTINUATION_WELSH,
+              NORTHERN_IRELAND_HOUSEHOLD_CONTINUATION,
+              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_ENGLAND_AND_WALES,
+              CCS_POSTBACK_CONTINUATION_QUESTIONNAIRE_FOR_WALES_WELSH));
+
+  public static boolean isContinuationQuestionnaireType(String questionnaireId) {
+    String questionnaireType = questionnaireId.substring(0, 2);
+
+    return continuationQuestionnaireTypes.contains(questionnaireType);
+  }
+}

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverIT.java
@@ -41,7 +41,7 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 public class UacUpdatedReceiverIT {
   private static final String TEST_CASE_ID = "test_case_id";
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
-  private static final String TEST_QID = "1120000000000100";
+  private static final String TEST_QID = "0120000000000100";
   private static final String UAC_UPDATE_ROUTING_KEY = "event.uac.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverIT.java
@@ -41,7 +41,7 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 public class UacUpdatedReceiverIT {
   private static final String TEST_CASE_ID = "test_case_id";
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
-  private static final String TEST_QID = "test_qid";
+  private static final String TEST_QID = "1120000000000100";
   private static final String UAC_UPDATE_ROUTING_KEY = "event.uac.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/UacUpdatedReceiverTest.java
@@ -41,6 +41,7 @@ public class UacUpdatedReceiverTest {
     Uac uac = new Uac();
     uac.setActive(false);
     uac.setCaseId("test case ID");
+    uac.setQuestionnaireId("0120000000000100");
     Payload payload = new Payload();
     payload.setUac(uac);
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
@@ -91,6 +92,32 @@ public class UacUpdatedReceiverTest {
     uac.setActive(false);
     uac.setCaseId(null);
     uac.setQuestionnaireId("test questionnaire id");
+    Payload payload = new Payload();
+    payload.setUac(uac);
+    Event event = new Event();
+    event.setTransactionId("test transaction id");
+    event.setChannel("test channel");
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setPayload(payload);
+    responseManagementEvent.setEvent(event);
+
+    // When
+    underTest.receiveMessage(responseManagementEvent);
+
+    // Then
+    verify(caseClient, never()).getCaseFromCaseId(any());
+    verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+  }
+
+  @Test
+  public void testReceivedMessageContinuationQuestionnaireQid() {
+    // Given
+    Uac uac = new Uac();
+    uac.setActive(false);
+    uac.setCaseId(null);
+    String englandHouseholdContinuationQid = "1120000000000100";
+    uac.setQuestionnaireId(englandHouseholdContinuationQid);
+
     Payload payload = new Payload();
     payload.setUac(uac);
     Event event = new Event();

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/util/QuestionnaireTypeHelperTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/util/QuestionnaireTypeHelperTest.java
@@ -1,0 +1,86 @@
+package uk.gov.ons.census.fwmtadapter.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import uk.gov.ons.census.fwmtadapter.utility.QuestionnaireTypeHelper;
+
+public class QuestionnaireTypeHelperTest {
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandHouseholdContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("11");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesEnglishHouseholdContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("12");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesWelshHouseholdContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("13");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandHouseholdContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("14");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeCCSPostbackEnglandAndWalesContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("61");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeCCSPostbackWalesWelshContinuation() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("63");
+
+    // Then
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  public void testIsNotContinuationQuestionnaireType() {
+    // Given
+
+    // When
+    boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("99");
+
+    // Then
+    assertThat(actual).isFalse();
+  }
+}

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/util/QuestionnaireTypeHelperTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/util/QuestionnaireTypeHelperTest.java
@@ -9,8 +9,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeEnglandHouseholdContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("11");
 
@@ -20,8 +18,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeWalesEnglishHouseholdContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("12");
 
@@ -31,8 +27,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeWalesWelshHouseholdContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("13");
 
@@ -42,8 +36,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeNorthernIrelandHouseholdContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("14");
 
@@ -53,8 +45,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeCCSPostbackEnglandAndWalesContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("61");
 
@@ -64,8 +54,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testValidQuestionnaireTypeCCSPostbackWalesWelshContinuation() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("63");
 
@@ -75,8 +63,6 @@ public class QuestionnaireTypeHelperTest {
 
   @Test
   public void testIsNotContinuationQuestionnaireType() {
-    // Given
-
     // When
     boolean actual = QuestionnaireTypeHelper.isContinuationQuestionnaireType("99");
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When we receive a PQRS receipt for a continuation form we need ensure that fieldwork are not sent an Action Cancel instruction from this so that follow-ups can continue until the main form is receipted. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Validation to ensure continuation questionnaire types are ignored
* Added and updated tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Ensure tests all pass and run acceptance tests from link below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/cvCv6U1R/499-do-not-send-a-cancel-message-when-a-continuation-form-is-completed-3
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/159