### PR TITLE
Handle estab address level refusal & tests

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
@@ -14,9 +14,12 @@ import uk.gov.ons.census.fwmtadapter.model.dto.field.ActionInstruction;
 
 @MessageEndpoint
 public class RefusalReceiver {
+
   private final String outboundExchange;
   private final CaseClient caseClient;
   private final RabbitTemplate rabbitTemplate;
+
+  private static final String ESTAB_ADDRESS_LEVEL = "E";
 
   public RefusalReceiver(
       RabbitTemplate rabbitTemplate,
@@ -41,8 +44,12 @@ public class RefusalReceiver {
     }
 
     String caseId = event.getPayload().getRefusal().getCollectionCase().getId();
-
     CaseContainerDto caseContainerDto = caseClient.getCaseFromCaseId(caseId);
+
+    // Ignore refusal if estab level case - we shouldn't get these from any channel except Field
+    if (caseContainerDto.getAddressLevel().equals(ESTAB_ADDRESS_LEVEL)) {
+      return;
+    }
 
     ActionCancel actionCancel = new ActionCancel();
     actionCancel.setCaseId(caseId);

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiver.java
@@ -20,6 +20,7 @@ public class RefusalReceiver {
   private final RabbitTemplate rabbitTemplate;
 
   private static final String ESTAB_ADDRESS_LEVEL = "E";
+  private static final String FIELD_CHANNEL = "FIELD";
 
   public RefusalReceiver(
       RabbitTemplate rabbitTemplate,
@@ -39,7 +40,7 @@ public class RefusalReceiver {
     }
 
     // Do not send refusal back to Field if from Field
-    if ("FIELD".equalsIgnoreCase(event.getEvent().getChannel())) {
+    if (FIELD_CHANNEL.equalsIgnoreCase(event.getEvent().getChannel())) {
       return;
     }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainerDto.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CaseContainerDto.java
@@ -10,4 +10,6 @@ public class CaseContainerDto {
 
   @JsonProperty("caseType")
   private String addressType;
+
+  private String addressLevel;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -58,7 +58,6 @@ public class RefusalReceiverIT {
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 
-  private final EasyRandom easyRandom = new EasyRandom();
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089));

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -48,6 +48,7 @@ public class RefusalReceiverIT {
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private static final String UNIT_ADDRESS_LEVEL = "U";
   private static final String ESTAB_ADDRESS_LEVEL = "E";
+  private static final String FIELD_CHANNEL = "FIELD";
 
   @Value("${queueconfig.case-event-exchange}")
   private String caseEventExchange;
@@ -131,14 +132,14 @@ public class RefusalReceiverIT {
     responseManagementEvent.setPayload(payload);
     Event event = new Event();
     event.setType(EventType.REFUSAL_RECEIVED);
-    event.setChannel("FIELD");
+    event.setChannel(FIELD_CHANNEL);
     responseManagementEvent.setEvent(event);
 
     // When
     rabbitQueueHelper.sendMessage(caseEventExchange, REFUSAL_ROUTING_KEY, responseManagementEvent);
 
     // Then
-    assertThat(rabbitQueueHelper.getMessage(outboundQueue)).isNull();
+    rabbitQueueHelper.checkNoMessage(outboundQueue);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -102,6 +102,7 @@ public class RefusalReceiverIT {
                     .withHeader("Content-Type", "application/json")
                     .withBody(returnJson)));
 
+    // When
     rabbitQueueHelper.sendMessage(caseEventExchange, REFUSAL_ROUTING_KEY, responseManagementEvent);
 
     // Then
@@ -179,6 +180,6 @@ public class RefusalReceiverIT {
     rabbitQueueHelper.sendMessage(caseEventExchange, REFUSAL_ROUTING_KEY, responseManagementEvent);
 
     // Then
-    assertThat(rabbitQueueHelper.getMessage(outboundQueue)).isNull();
+    rabbitQueueHelper.checkNoMessage(outboundQueue);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverIT.java
@@ -13,7 +13,6 @@ import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
-import org.jeasy.random.EasyRandom;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/RefusalReceiverTest.java
@@ -19,6 +19,7 @@ public class RefusalReceiverTest {
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
   private static final String UNIT_ADDRESS_LEVEL = "U";
   private static final String ESTAB_ADDRESS_LEVEL = "E";
+  private static final String FIELD_CHANNEL = "FIELD";
 
   private EasyRandom easyRandom = new EasyRandom();
 
@@ -63,7 +64,7 @@ public class RefusalReceiverTest {
     RefusalReceiver underTest = new RefusalReceiver(rabbitTemplate, "TEST EXCHANGE", null);
     ResponseManagementEvent event = easyRandom.nextObject(ResponseManagementEvent.class);
     event.getEvent().setType(EventType.REFUSAL_RECEIVED);
-    event.getEvent().setChannel("FIELD");
+    event.getEvent().setChannel(FIELD_CHANNEL);
     underTest.receiveMessage(event);
 
     // Then
@@ -80,7 +81,6 @@ public class RefusalReceiverTest {
     event.getEvent().setChannel("CC");
     event.getPayload().getRefusal().getCollectionCase().setId(TEST_CASE_ID);
 
-    // When
     CaseClient caseClient = mock(CaseClient.class);
     CaseContainerDto caseContainerDto = new CaseContainerDto();
     caseContainerDto.setCaseId(TEST_CASE_ID);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can safely ignore any refusal message which comes into the fieldwork-adapter which is from a non-Field channel for an estab address-level case. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Add check after retrieving the case from the case-api to see if the address level is `E`.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run maven build and acceptance tests against the links in this PR. There should be no regression.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/i0aebEJC/534-handle-ce-and-spg-refusals-for-estab-address-level-cases-5

https://github.com/ONSdigital/census-rm-case-processor/pull/103