### PR TITLE
RMC-317: Add handDelivery on outbound messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
@@ -39,7 +39,7 @@ public class ActionFieldReceiver {
     actionInstruction.setEstabType(followup.getEstabType());
     actionInstruction.setFieldCoordinatorId(followup.getFieldCoordinatorId());
     actionInstruction.setFieldOfficerId(followup.getFieldOfficerId());
-    actionInstruction.setHandDeliver(false); // TODO: This needs to be based on treatment code
+    actionInstruction.setHandDeliver(followup.isHandDelivery());
     if (followup.getLatitude() != null && !followup.getLatitude().isBlank()) {
       actionInstruction.setLatitude(Double.parseDouble(followup.getLatitude()));
     }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
@@ -39,7 +39,7 @@ public class ActionFieldReceiver {
     actionInstruction.setEstabType(followup.getEstabType());
     actionInstruction.setFieldCoordinatorId(followup.getFieldCoordinatorId());
     actionInstruction.setFieldOfficerId(followup.getFieldOfficerId());
-    actionInstruction.setHandDeliver(followup.isHandDelivery());
+    actionInstruction.setHandDeliver(followup.getHandDelivery());
     if (followup.getLatitude() != null && !followup.getLatitude().isBlank()) {
       actionInstruction.setLatitude(Double.parseDouble(followup.getLatitude()));
     }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
@@ -33,4 +33,5 @@ public class CollectionCase {
   private Integer ceActualResponses;
   private Boolean addressInvalid;
   private Boolean undeliveredAsAddressed;
+  private boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
@@ -31,4 +31,5 @@ public class FieldworkFollowup {
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;
   private Boolean receipted;
+  private boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
@@ -31,5 +31,5 @@ public class FieldworkFollowup {
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;
   private Boolean receipted;
-  private boolean handDelivery;
+  private Boolean handDelivery;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverIT.java
@@ -53,6 +53,7 @@ public class ActionFieldReceiverIT {
     fieldworkFollowup.setSurveyName("CENSUS");
     fieldworkFollowup.setUndeliveredAsAddress(false);
     fieldworkFollowup.setBlankQreReturned(false);
+    fieldworkFollowup.setHandDelivery(true);
 
     rabbitQueueHelper.sendMessage(actionFieldQueue, fieldworkFollowup);
 
@@ -84,6 +85,7 @@ public class ActionFieldReceiverIT {
             "fieldOfficerId");
     assertThat(actionInstruction.getCeExpectedCapacity())
         .isEqualTo(fieldworkFollowup.getCeExpectedCapacity());
+    assertThat(actionInstruction.isHandDeliver()).isTrue();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
@@ -30,6 +30,7 @@ public class ActionFieldReceiverTest {
     fieldworkFollowup.setAddressType("HH");
     fieldworkFollowup.setCeActualResponses(null);
     fieldworkFollowup.setCeExpectedCapacity(null);
+    fieldworkFollowup.setHandDelivery(true);
 
     // When
     underTest.receiveMessage(fieldworkFollowup);
@@ -69,6 +70,7 @@ public class ActionFieldReceiverTest {
     assertThat(actionInstruction.isCe1Complete()).isFalse();
     assertThat(actionInstruction.getCeExpectedCapacity()).isNull();
     assertThat(actionInstruction.getCeActualResponses()).isNull();
+    assertThat(actionInstruction.isHandDeliver()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to add `handDeliver` bool flag on each of our outgoing Action Instruction `CREATE` messages to Field. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated the receiver to include `handDeliver` in the sent msg

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check build, run ATs against links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/774V6fGU/580-add-handdelivery-flag-to-casecreated-and-caseupdated-events-and-case-api-8

https://github.com/ONSdigital/census-rm-ddl/pull/38
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/191
https://github.com/ONSdigital/census-rm-action-worker/pull/10
https://github.com/ONSdigital/census-rm-case-processor/pull/112
https://github.com/ONSdigital/census-rm-action-scheduler/pull/65