### PR TITLE
Handle FWMT CREATE from CaseCreated RM message

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -71,7 +71,7 @@ public class CaseUpdatedReceiver {
     actionInstruction.setOa(caze.getOa());
     actionInstruction.setOrganisationName(caze.getAddress().getOrganisationName());
     actionInstruction.setPostcode(caze.getAddress().getPostcode());
-    // actionInstruction.setSurveyName(caze.getSurveyName()); TODO: We might need to add this
+    actionInstruction.setSurveyName(caze.getSurvey());
     actionInstruction.setTownName(caze.getAddress().getTownName());
     actionInstruction.setUprn(caze.getAddress().getUprn());
     actionInstruction.setUndeliveredAsAddress(caze.getUndeliveredAsAddressed());

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -5,9 +5,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.fwmtadapter.model.dto.CollectionCase;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCreateActionInstruction;
 
 @MessageEndpoint
 public class CaseUpdatedReceiver {
@@ -27,13 +29,54 @@ public class CaseUpdatedReceiver {
   public void receiveMessage(ResponseManagementEvent event) {
     if (canIgnoreEvent(event)) return;
 
-    if (event.getPayload().getMetadata().getFieldDecision() == ActionInstructionType.CLOSE) {
+    ActionInstructionType fieldDecision = event.getPayload().getMetadata().getFieldDecision();
+
+    if (fieldDecision == ActionInstructionType.CLOSE) {
       handleCloseDecision(event);
+      return;
+    } else if (fieldDecision == ActionInstructionType.CREATE) {
+      handleCreateDecision(event);
       return;
     }
     throw new RuntimeException(
         String.format(
             "Unsupported field decision: %s", event.getPayload().getMetadata().getFieldDecision()));
+  }
+
+  private void handleCreateDecision(ResponseManagementEvent event) {
+    CollectionCase caze = event.getPayload().getCollectionCase();
+
+    FwmtCreateActionInstruction actionInstruction = new FwmtCreateActionInstruction();
+    actionInstruction.setActionInstruction(ActionInstructionType.CREATE);
+    actionInstruction.setAddressLevel(caze.getAddress().getAddressLevel());
+    actionInstruction.setAddressLine1(caze.getAddress().getAddressLine1());
+    actionInstruction.setAddressLine2(caze.getAddress().getAddressLine2());
+    actionInstruction.setAddressLine3(caze.getAddress().getAddressLine3());
+    actionInstruction.setAddressType(caze.getAddress().getAddressType());
+    actionInstruction.setCaseId(caze.getId());
+    actionInstruction.setCaseRef(caze.getCaseRef());
+    actionInstruction.setCe1Complete(getCEComplete(caze));
+    actionInstruction.setCeActualResponses(caze.getCeActualResponses());
+    actionInstruction.setCeExpectedCapacity(caze.getCeExpectedCapacity());
+    actionInstruction.setEstabType(caze.getAddress().getEstabType());
+    actionInstruction.setFieldCoordinatorId(caze.getFieldCoordinatorId());
+    actionInstruction.setFieldOfficerId(caze.getFieldOfficerId());
+    actionInstruction.setHandDeliver(caze.isHandDelivery());
+    if (caze.getAddress().getLatitude() != null && !caze.getAddress().getLatitude().isBlank()) {
+      actionInstruction.setLatitude(Double.parseDouble(caze.getAddress().getLatitude()));
+    }
+    if (caze.getAddress().getLongitude() != null && !caze.getAddress().getLongitude().isBlank()) {
+      actionInstruction.setLongitude(Double.parseDouble(caze.getAddress().getLongitude()));
+    }
+    actionInstruction.setOa(caze.getOa());
+    actionInstruction.setOrganisationName(caze.getAddress().getOrganisationName());
+    actionInstruction.setPostcode(caze.getAddress().getPostcode());
+    // actionInstruction.setSurveyName(caze.getSurveyName()); TODO: We might need to add this
+    actionInstruction.setTownName(caze.getAddress().getTownName());
+    actionInstruction.setUprn(caze.getAddress().getUprn());
+    actionInstruction.setUndeliveredAsAddress(caze.getUndeliveredAsAddressed());
+
+    rabbitTemplate.convertAndSend(outboundExchange, "", actionInstruction);
   }
 
   private void handleCloseDecision(ResponseManagementEvent event) {
@@ -52,5 +95,16 @@ public class CaseUpdatedReceiver {
   private boolean canIgnoreEvent(ResponseManagementEvent event) {
     return event.getPayload().getMetadata() == null
         || event.getPayload().getMetadata().getFieldDecision() == null;
+  }
+
+  private Boolean getCEComplete(CollectionCase caze) {
+    if (caze.getAddress().getAddressType().equals("CE")
+        && caze.getAddress().getAddressLevel().equals("E")) {
+      if (caze.getReceiptReceived() != null) {
+        return caze.getReceiptReceived();
+      }
+    }
+
+    return false;
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -99,10 +99,9 @@ public class CaseUpdatedReceiver {
 
   private Boolean getCEComplete(CollectionCase caze) {
     if (caze.getAddress().getAddressType().equals("CE")
-        && caze.getAddress().getAddressLevel().equals("E")) {
-      if (caze.getReceiptReceived() != null) {
-        return caze.getReceiptReceived();
-      }
+        && caze.getAddress().getAddressLevel().equals("E")
+        && caze.getReceiptReceived() != null) {
+      return caze.getReceiptReceived();
     }
 
     return false;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCreateActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCreateActionInstruction.java
@@ -27,5 +27,5 @@ public class FwmtCreateActionInstruction {
   private boolean handDeliver;
   private Integer ceExpectedCapacity;
   private Integer ceActualResponses;
-  private boolean undeliveredAsAddress; // TODO: This will probably be removed
+  private Boolean undeliveredAsAddress; // TODO: This will probably be removed
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCreateActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCreateActionInstruction.java
@@ -27,5 +27,5 @@ public class FwmtCreateActionInstruction {
   private boolean handDeliver;
   private Integer ceExpectedCapacity;
   private Integer ceActualResponses;
-  private Boolean undeliveredAsAddress; // TODO: This will probably be removed
+  private Boolean undeliveredAsAddress;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
@@ -23,6 +23,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.Payload;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCreateActionInstruction;
 import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 
 @ContextConfiguration
@@ -37,6 +38,9 @@ public class CaseUpdatedReceiverIT {
   private static final String TEST_CASE_REF = "test_case_ref";
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
   private static final String TEST_ADDRESS_LEVEL = "test_address_level";
+  private static final String TEST_ADDRESS_LINE1 = "test_address_line_1";
+  private static final String TEST_ADDRESS_POST_TOWN = "test_address_post_town";
+  private static final String TEST_ADDRESS_POSTCODE = "test_address_postcode";
 
   @Value("${queueconfig.case-event-exchange}")
   private String caseEventExchange;
@@ -89,5 +93,50 @@ public class CaseUpdatedReceiverIT {
     assertThat(actionInstruction.getCaseRef()).isEqualTo(TEST_CASE_REF);
     assertThat(actionInstruction.getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);
     assertThat(actionInstruction.getAddressLevel()).isEqualTo(TEST_ADDRESS_LEVEL);
+  }
+
+  @Test
+  public void testGoodNewCCSCaseMessage() throws InterruptedException, IOException {
+    // Given
+    BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(ADAPTER_OUTBOUND_QUEUE);
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId(TEST_CASE_ID);
+    collectionCase.setCaseRef(TEST_CASE_REF);
+    collectionCase.setUndeliveredAsAddressed(Boolean.FALSE);
+    Address address = new Address();
+    address.setAddressLevel(TEST_ADDRESS_LEVEL);
+    address.setAddressType(TEST_ADDRESS_TYPE);
+    address.setAddressLine1(TEST_ADDRESS_LINE1);
+    address.setTownName(TEST_ADDRESS_POST_TOWN);
+    address.setPostcode(TEST_ADDRESS_POSTCODE);
+    collectionCase.setAddress(address);
+
+    Metadata metadata = new Metadata();
+    metadata.setFieldDecision(ActionInstructionType.CREATE);
+
+    Payload payload = new Payload();
+    payload.setCollectionCase(collectionCase);
+    payload.setMetadata(metadata);
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setPayload(payload);
+
+    // when
+    rabbitQueueHelper.sendMessage(
+        caseEventExchange, CASE_UPDATE_ROUTING_KEY, responseManagementEvent);
+
+    // then
+    String actualMessage = rabbitQueueHelper.getMessage(outboundQueue);
+    ObjectMapper objectMapper = new ObjectMapper();
+    FwmtCreateActionInstruction actionInstruction =
+        objectMapper.readValue(actualMessage, FwmtCreateActionInstruction.class);
+    assertThat(actionInstruction.getActionInstruction()).isEqualTo(ActionInstructionType.CREATE);
+    assertThat(actionInstruction.getCaseId()).isEqualTo(TEST_CASE_ID);
+    assertThat(actionInstruction.getCaseRef()).isEqualTo(TEST_CASE_REF);
+    assertThat(actionInstruction.getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);
+    assertThat(actionInstruction.getAddressLevel()).isEqualTo(TEST_ADDRESS_LEVEL);
+    assertThat(actionInstruction.getAddressLine1()).isEqualTo(TEST_ADDRESS_LINE1);
+    assertThat(actionInstruction.getTownName()).isEqualTo(TEST_ADDRESS_POST_TOWN);
+    assertThat(actionInstruction.getPostcode()).isEqualTo(TEST_ADDRESS_POSTCODE);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
@@ -35,7 +35,7 @@ public class CaseUpdatedReceiverIT {
   private static final String CASE_UPDATE_ROUTING_KEY = "event.case.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private static final String TEST_CASE_ID = "test_case_id";
-  private static final String TEST_CASE_REF = "test_case_ref";
+  private static final String TEST_CASE_REF = "test_case_ref"; // This exists
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
   private static final String TEST_ADDRESS_LEVEL = "test_address_level";
   private static final String TEST_ADDRESS_LINE1 = "test_address_line_1";

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
@@ -20,6 +20,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.Payload;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCreateActionInstruction;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseUpdatedReceiverTest {
@@ -65,6 +66,43 @@ public class CaseUpdatedReceiverTest {
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
     assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CLOSE);
+  }
+
+  @Test
+  public void testReceiveCreateDecision() {
+    // Given
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId("testId");
+    collectionCase.setCaseRef("testRef");
+    collectionCase.setUndeliveredAsAddressed(Boolean.FALSE);
+    Address address = new Address();
+    address.setAddressLevel("U");
+    address.setAddressType("test address type");
+    collectionCase.setAddress(address);
+
+    Metadata metadata = new Metadata();
+    metadata.setFieldDecision(ActionInstructionType.CREATE);
+
+    Payload payload = new Payload();
+    payload.setCollectionCase(collectionCase);
+    payload.setMetadata(metadata);
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setPayload(payload);
+
+    // When
+    underTest.receiveMessage(responseManagementEvent);
+
+    // Then
+    ArgumentCaptor<FwmtCreateActionInstruction> aiArgumentCaptor =
+        ArgumentCaptor.forClass(FwmtCreateActionInstruction.class);
+    verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
+    FwmtCreateActionInstruction actualAi = aiArgumentCaptor.getValue();
+    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
+    assertThat(actualAi.getAddressType()).isEqualTo("test address type");
+    assertThat(actualAi.getAddressLevel()).isEqualTo("U");
+    assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CREATE);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
We want to drive FWMT via regular RM events. Case Processor was re-using the mechanism that Action Worker uses to send messages directly to Fieldwork Adapter, so we wanted to refactor that away and only use the regular CaseCreated RM event.

# What has changed
Got rid of any and every reference to the old direct message. Ensured that a CaseCreated RM event is emitted when a CCS case is created.

# How to test?
Run the ATs. There should be zero regression.

# Links
Trello: https://trello.com/c/ONAETtD2