### PR TITLE
Populate survey name on field close message

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -44,7 +44,7 @@ public class CaseUpdatedReceiver {
     actionInstruction.setAddressType(
         event.getPayload().getCollectionCase().getAddress().getAddressType());
     actionInstruction.setCaseId(event.getPayload().getCollectionCase().getId());
-    actionInstruction.setCaseRef(event.getPayload().getCollectionCase().getCaseRef());
+    actionInstruction.setSurveyName(event.getPayload().getCollectionCase().getSurvey());
 
     rabbitTemplate.convertAndSend(outboundExchange, "", actionInstruction);
   }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCloseActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCloseActionInstruction.java
@@ -9,5 +9,4 @@ public class FwmtCloseActionInstruction {
   private String addressType;
   private String addressLevel;
   private String caseId;
-  private String caseRef;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
@@ -34,7 +34,7 @@ public class CaseUpdatedReceiverIT {
   private static final String CASE_UPDATE_ROUTING_KEY = "event.case.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private static final String TEST_CASE_ID = "test_case_id";
-  private static final String TEST_CASE_REF = "test_case_ref";
+  private static final String TEST_SURVEY = "test_survey";
   private static final String TEST_ADDRESS_TYPE = "test_address_type";
   private static final String TEST_ADDRESS_LEVEL = "test_address_level";
 
@@ -59,7 +59,7 @@ public class CaseUpdatedReceiverIT {
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(ADAPTER_OUTBOUND_QUEUE);
     CollectionCase collectionCase = new CollectionCase();
     collectionCase.setId(TEST_CASE_ID);
-    collectionCase.setCaseRef(TEST_CASE_REF);
+    collectionCase.setSurvey(TEST_SURVEY);
     Address address = new Address();
     address.setAddressLevel(TEST_ADDRESS_LEVEL);
     address.setAddressType(TEST_ADDRESS_TYPE);
@@ -86,7 +86,7 @@ public class CaseUpdatedReceiverIT {
         objectMapper.readValue(actualMessage, FwmtCloseActionInstruction.class);
     assertThat(actionInstruction.getActionInstruction()).isEqualTo(ActionInstructionType.CLOSE);
     assertThat(actionInstruction.getCaseId()).isEqualTo(TEST_CASE_ID);
-    assertThat(actionInstruction.getCaseRef()).isEqualTo(TEST_CASE_REF);
+    assertThat(actionInstruction.getSurveyName()).isEqualTo(TEST_SURVEY);
     assertThat(actionInstruction.getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);
     assertThat(actionInstruction.getAddressLevel()).isEqualTo(TEST_ADDRESS_LEVEL);
   }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
@@ -36,7 +36,7 @@ public class CaseUpdatedReceiverTest {
     // Given
     CollectionCase collectionCase = new CollectionCase();
     collectionCase.setId("testId");
-    collectionCase.setCaseRef("testRef");
+    collectionCase.setSurvey("CENSUS");
     Address address = new Address();
     address.setAddressLevel("U");
     address.setAddressType("test address type");
@@ -61,7 +61,7 @@ public class CaseUpdatedReceiverTest {
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtCloseActionInstruction actualAi = aiArgumentCaptor.getValue();
     assertThat(actualAi.getCaseId()).isEqualTo("testId");
-    assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
+    assertThat(actualAi.getSurveyName()).isEqualTo("CENSUS");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
     assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CLOSE);


### PR DESCRIPTION
# Motivation and Context
We should drop caseRef and populate surveyName to match with the expected interface with FWMT.

# What has changed
* Populate survey name on field close message
* Remove case ref from field close message
* Update tests

# How to test?
Build and run with linked AT branch

# Links
https://trello.com/c/nwGrBR4Q/639-tweak-outbound-fwmt-close-msg-to-match-interface
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/200