### PR TITLE
Include CE exected and actual responses on CLOSE

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -94,6 +94,13 @@ public class CaseUpdatedReceiver {
     actionInstruction.setCaseId(event.getPayload().getCollectionCase().getId());
     actionInstruction.setSurveyName(event.getPayload().getCollectionCase().getSurvey());
 
+    // These have been added in because we can't guarantee the order that we would publish separate
+    // UPDATE and CLOSE messages, which would be published simultaneously
+    actionInstruction.setCeActualResponses(
+        event.getPayload().getCollectionCase().getCeActualResponses());
+    actionInstruction.setCeExpectedCapacity(
+        event.getPayload().getCollectionCase().getCeExpectedCapacity());
+
     rabbitTemplate.convertAndSend(outboundExchange, "", actionInstruction);
   }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCloseActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCloseActionInstruction.java
@@ -9,4 +9,6 @@ public class FwmtCloseActionInstruction {
   private String addressType;
   private String addressLevel;
   private String caseId;
+  private Integer ceExpectedCapacity;
+  private Integer ceActualResponses;
 }


### PR DESCRIPTION
# Motivation and Context
We don't want to publish both an UPDATE and a CLOSE simultaneously when a CE Unit has reached its expected count, because we can't guarantee order of delivery.

# What has changed
Added actual & expected counts to CLOSE messages to FWMT.

# How to test?
Run ATs. Zero regression.

# Links
Trello: https://trello.com/c/GapIaH4L