### PR TITLE
Remove CE check on secure establishment field

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -81,7 +81,7 @@ public class CaseUpdatedReceiver {
     actionInstruction.setUprn(caze.getAddress().getUprn());
     actionInstruction.setUndeliveredAsAddress(caze.getUndeliveredAsAddressed());
 
-    if (caze.getCaseType().equals("CE")) {
+    if (caze.getMetadata() != null) {
       actionInstruction.setSecureEstablishment(caze.getMetadata().getSecureEstablishment());
     }
 

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
@@ -228,6 +228,49 @@ public class CaseUpdatedReceiverTest {
   }
 
   @Test
+  public void testReceiveUpdateDecisionSPG() {
+    // Given
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId("testId");
+    collectionCase.setCaseRef("testRef");
+    collectionCase.setUndeliveredAsAddressed(Boolean.FALSE);
+    collectionCase.setCaseType("SPG");
+
+    CaseMetadata ceMetadata = new CaseMetadata();
+    ceMetadata.setSecureEstablishment(true);
+    collectionCase.setMetadata(ceMetadata);
+    Address address = new Address();
+    address.setAddressLevel("U");
+    address.setAddressType("test address type");
+    collectionCase.setAddress(address);
+
+    Metadata metadata = new Metadata();
+    metadata.setFieldDecision(ActionInstructionType.UPDATE);
+
+    Payload payload = new Payload();
+    payload.setCollectionCase(collectionCase);
+    payload.setMetadata(metadata);
+
+    ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
+    responseManagementEvent.setPayload(payload);
+
+    // When
+    underTest.receiveMessage(responseManagementEvent);
+
+    // Then
+    ArgumentCaptor<FwmtActionInstruction> aiArgumentCaptor =
+        ArgumentCaptor.forClass(FwmtActionInstruction.class);
+    verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
+    FwmtActionInstruction actualAi = aiArgumentCaptor.getValue();
+    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
+    assertThat(actualAi.getAddressType()).isEqualTo("test address type");
+    assertThat(actualAi.getAddressLevel()).isEqualTo("U");
+    assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.UPDATE);
+    assertThat(actualAi.getSecureEstablishment()).isTrue();
+  }
+
+  @Test
   public void testIgnoresEventWithNoMetadata() {
     // Given
     CollectionCase collectionCase = new CollectionCase();


### PR DESCRIPTION
# Motivation and Context
We're now sending whatever data we have instead of conditioning on case type.

# What has changed
* Remove CE check on secure establishment field
* Add test for SPG type cases

# How to test?
Build and run linked AT branch.

# Links
https://trello.com/c/ELwJGrfA/716-rmc-341-check-spg-cases-against-new-cesecure-column-5
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/215