### PR TITLE
Set secure estab field on all cases

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
@@ -54,7 +54,7 @@ public class ActionFieldReceiver {
     actionInstruction.setUprn(followup.getUprn());
     actionInstruction.setUndeliveredAsAddress(followup.getUndeliveredAsAddress()); // TODO: Delete?
 
-    if (followup.getAddressType().equals("CE")) {
+    if (followup.getMetadata() != null) {
       actionInstruction.setSecureEstablishment(followup.getMetadata().getSecureEstablishment());
     }
 

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
@@ -11,7 +11,6 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.gov.ons.census.fwmtadapter.model.dto.CaseMetadata;
 import uk.gov.ons.census.fwmtadapter.model.dto.FieldworkFollowup;
-import uk.gov.ons.census.fwmtadapter.model.dto.Metadata;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
 
 public class ActionFieldReceiverTest {


### PR DESCRIPTION
# Motivation and Context
The secure estab field was not being set on scheduled FIELD followup messages

# What has changed
* Set secure estab field whenever present on followup messages

# How to test?
Build and run linked AT's

# Links
https://trello.com/c/mzeiV7JC/750-spg-cases-not-sending-secure-estab-to-field
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/218
