### PR TITLE
RMC-173 Blank Questionnaires Revenge

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -31,6 +31,7 @@ public class CaseUpdatedReceiver {
 
     ActionInstructionType fieldDecision = event.getPayload().getMetadata().getFieldDecision();
 
+    // TODO switch?
     if (fieldDecision == ActionInstructionType.CLOSE) {
       handleCloseDecision(event);
       return;
@@ -84,6 +85,8 @@ public class CaseUpdatedReceiver {
     if (caze.getMetadata() != null) {
       actionInstruction.setSecureEstablishment(caze.getMetadata().getSecureEstablishment());
     }
+
+    actionInstruction.setBlankFormReturned(event.getPayload().getMetadata().getBlankQuestionnaireReceived());
 
     rabbitTemplate.convertAndSend(outboundExchange, "", actionInstruction);
   }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Metadata.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Metadata.java
@@ -7,4 +7,5 @@ import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 public class Metadata {
   private ActionInstructionType fieldDecision;
   private EventType causeEventType;
+  private Boolean blankQuestionnaireReceived;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -33,5 +33,4 @@ public class FwmtActionInstruction {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean secureEstablishment;
-
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -29,7 +29,9 @@ public class FwmtActionInstruction {
   private Integer ceExpectedCapacity;
   private Integer ceActualResponses;
   private Boolean undeliveredAsAddress;
+  private Boolean blankFormReturned;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Boolean secureEstablishment;
+
 }


### PR DESCRIPTION
# Motivation and Context
For the blank questionnaire feature we need to be able to send this field to FWMT in the `UPDATE` message.

# What has changed
* Pass blank questionnaire field through

# How to test?
Build and run with linked services and run branch AT's

# Links
https://trello.com/c/EmrziSj3/439-rmc-173-blank-questionnaire-returned-21
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/38
https://github.com/ONSdigital/census-rm-case-processor/pull/128
https://github.com/ONSdigital/census-rm-ddl/pull/47
https://github.com/ONSdigital/census-rm-pubsub/pull/40
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/222