### PR TITLE
Changed CLOSE to CANCEL

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiver.java
@@ -9,7 +9,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.CollectionCase;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
-import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCancelActionInstruction;
 
 @MessageEndpoint
 public class CaseUpdatedReceiver {
@@ -31,8 +31,8 @@ public class CaseUpdatedReceiver {
 
     ActionInstructionType fieldDecision = event.getPayload().getMetadata().getFieldDecision();
 
-    if (fieldDecision == ActionInstructionType.CLOSE) {
-      handleCloseDecision(event);
+    if (fieldDecision == ActionInstructionType.CANCEL) {
+      handleCancelDecision(event);
       return;
     }
 
@@ -88,9 +88,9 @@ public class CaseUpdatedReceiver {
     rabbitTemplate.convertAndSend(outboundExchange, "", actionInstruction);
   }
 
-  private void handleCloseDecision(ResponseManagementEvent event) {
-    FwmtCloseActionInstruction actionInstruction = new FwmtCloseActionInstruction();
-    actionInstruction.setActionInstruction(ActionInstructionType.CLOSE);
+  private void handleCancelDecision(ResponseManagementEvent event) {
+    FwmtCancelActionInstruction actionInstruction = new FwmtCancelActionInstruction();
+    actionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
     actionInstruction.setAddressLevel(
         event.getPayload().getCollectionCase().getAddress().getAddressLevel());
     actionInstruction.setAddressType(
@@ -99,7 +99,7 @@ public class CaseUpdatedReceiver {
     actionInstruction.setSurveyName(event.getPayload().getCollectionCase().getSurvey());
 
     // These have been added in because we can't guarantee the order that we would publish separate
-    // UPDATE and CLOSE messages, which would be published simultaneously
+    // UPDATE and CANCEL messages, which would be published simultaneously
     actionInstruction.setCeActualResponses(
         event.getPayload().getCollectionCase().getCeActualResponses());
     actionInstruction.setCeExpectedCapacity(

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/ActionInstructionType.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/ActionInstructionType.java
@@ -5,5 +5,5 @@ public enum ActionInstructionType {
   UPDATE,
   PAUSE,
   REACTIVATE,
-  CLOSE
+  CANCEL
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
@@ -3,7 +3,7 @@ package uk.gov.ons.census.fwmtadapter.model.dto.fwmt;
 import lombok.Data;
 
 @Data
-public class FwmtCloseActionInstruction {
+public class FwmtCancelActionInstruction {
   private ActionInstructionType actionInstruction;
   private String surveyName;
   private String addressType;

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverIT.java
@@ -23,7 +23,7 @@ import uk.gov.ons.census.fwmtadapter.model.dto.Payload;
 import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
-import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCancelActionInstruction;
 import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 
 @ContextConfiguration
@@ -60,7 +60,7 @@ public class CaseUpdatedReceiverIT {
   }
 
   @Test
-  public void testGoodCloseReceiptMessage() throws InterruptedException, IOException {
+  public void testGoodCancelReceiptMessage() throws InterruptedException, IOException {
     // Given
     BlockingQueue<String> outboundQueue = rabbitQueueHelper.listen(ADAPTER_OUTBOUND_QUEUE);
     CollectionCase collectionCase = new CollectionCase();
@@ -72,7 +72,7 @@ public class CaseUpdatedReceiverIT {
     collectionCase.setAddress(address);
 
     Metadata metadata = new Metadata();
-    metadata.setFieldDecision(ActionInstructionType.CLOSE);
+    metadata.setFieldDecision(ActionInstructionType.CANCEL);
 
     Payload payload = new Payload();
     payload.setCollectionCase(collectionCase);
@@ -88,9 +88,9 @@ public class CaseUpdatedReceiverIT {
     // then
     String actualMessage = rabbitQueueHelper.getMessage(outboundQueue);
     ObjectMapper objectMapper = new ObjectMapper();
-    FwmtCloseActionInstruction actionInstruction =
-        objectMapper.readValue(actualMessage, FwmtCloseActionInstruction.class);
-    assertThat(actionInstruction.getActionInstruction()).isEqualTo(ActionInstructionType.CLOSE);
+    FwmtCancelActionInstruction actionInstruction =
+        objectMapper.readValue(actualMessage, FwmtCancelActionInstruction.class);
+    assertThat(actionInstruction.getActionInstruction()).isEqualTo(ActionInstructionType.CANCEL);
     assertThat(actionInstruction.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actionInstruction.getSurveyName()).isEqualTo(TEST_SURVEY);
     assertThat(actionInstruction.getAddressType()).isEqualTo(TEST_ADDRESS_TYPE);

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseUpdatedReceiverTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import uk.gov.ons.census.fwmtadapter.model.dto.*;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.ActionInstructionType;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
-import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCloseActionInstruction;
+import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCancelActionInstruction;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseUpdatedReceiverTest {
@@ -29,7 +29,7 @@ public class CaseUpdatedReceiverTest {
   @InjectMocks private CaseUpdatedReceiver underTest;
 
   @Test
-  public void testReceiveCloseDecision() {
+  public void testReceiveCancelDecision() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
     collectionCase.setId("testId");
@@ -40,7 +40,7 @@ public class CaseUpdatedReceiverTest {
     collectionCase.setAddress(address);
 
     Metadata metadata = new Metadata();
-    metadata.setFieldDecision(ActionInstructionType.CLOSE);
+    metadata.setFieldDecision(ActionInstructionType.CANCEL);
 
     Payload payload = new Payload();
     payload.setCollectionCase(collectionCase);
@@ -53,15 +53,15 @@ public class CaseUpdatedReceiverTest {
     underTest.receiveMessage(responseManagementEvent);
 
     // Then
-    ArgumentCaptor<FwmtCloseActionInstruction> aiArgumentCaptor =
-        ArgumentCaptor.forClass(FwmtCloseActionInstruction.class);
+    ArgumentCaptor<FwmtCancelActionInstruction> aiArgumentCaptor =
+        ArgumentCaptor.forClass(FwmtCancelActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
-    FwmtCloseActionInstruction actualAi = aiArgumentCaptor.getValue();
+    FwmtCancelActionInstruction actualAi = aiArgumentCaptor.getValue();
     assertThat(actualAi.getCaseId()).isEqualTo("testId");
     assertThat(actualAi.getSurveyName()).isEqualTo("CENSUS");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
-    assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CLOSE);
+    assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CANCEL);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
Better wording - less ambiguous 

# What has changed
Any reference to a CLOSE event has been changed to CANCEL
Changed name of FwmtCloseActionInstruction to FwmtCancelActionInstruction

# How to test?
Clone branch and build/test it

# Links
https://trello.com/c/3PljKzC2/770-change-field-close-message-to-cancels-5
