### PR TITLE
Remove arid

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Address.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Address.java
@@ -14,8 +14,7 @@ public class Address {
   private String longitude;
   private String uprn;
   private String apbCode;
-  private String arid;
-  private String estabArid;
+  private String estabUprn;
   private String addressType;
   private String addressLevel;
   private String estabType;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
@@ -11,7 +11,6 @@ public class FieldworkFollowup {
   private String postcode;
   private String estabType;
   private String organisationName;
-  private String arid;
   private String uprn;
   private String oa;
   private String latitude;


### PR DESCRIPTION
# Motivation and Context
ARID is dead. Long live ARID. May estab UPRN have a long and victorious reign.

# What has changed
ARID has been removed. Estab ARID has been usurped by Estab UPRN.

# How to test?
Run the ATs along with all the other PRs on the ticket.

# Links
Trello: https://trello.com/c/zm2Ssvnn