### PR TITLE
rename caseUpdated to caseReceiver

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
@@ -60,7 +60,7 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  public MessageChannel caseUpdatedInputChannel() {
+  public MessageChannel caseReceiverChannel() {
     return new DirectChannel();
   }
 
@@ -75,9 +75,9 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  public AmqpInboundChannelAdapter caseUpdatedInbound(
-      @Qualifier("caseUpdatedContainer") SimpleMessageListenerContainer listenerContainer,
-      @Qualifier("caseUpdatedInputChannel") MessageChannel channel) {
+  public AmqpInboundChannelAdapter caseReceivedInbound(
+      @Qualifier("caseReceivedContainer") SimpleMessageListenerContainer listenerContainer,
+      @Qualifier("caseReceiverChannel") MessageChannel channel) {
     AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);
     adapter.setOutputChannel(channel);
     return adapter;
@@ -89,7 +89,7 @@ public class MessageConsumerConfig {
   }
 
   @Bean
-  public SimpleMessageListenerContainer caseUpdatedContainer() {
+  public SimpleMessageListenerContainer caseReceivedContainer() {
     return setupListenerContainer(caseUpdatedQueue, ResponseManagementEvent.class);
   }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiver.java
@@ -13,12 +13,12 @@ import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCancelActionInstruction;
 
 @MessageEndpoint
-public class CaseUpdatedReceiver {
+public class CaseReceiver {
 
   private final RabbitTemplate rabbitTemplate;
   private final String outboundExchange;
 
-  public CaseUpdatedReceiver(
+  public CaseReceiver(
       RabbitTemplate rabbitTemplate,
       @Value("${queueconfig.outbound-exchange}") String outboundExchange) {
     this.rabbitTemplate = rabbitTemplate;
@@ -26,7 +26,7 @@ public class CaseUpdatedReceiver {
   }
 
   @Transactional
-  @ServiceActivator(inputChannel = "caseUpdatedInputChannel")
+  @ServiceActivator(inputChannel = "caseReceiverChannel")
   public void receiveMessage(ResponseManagementEvent event) {
     if (canIgnoreEvent(event)) return;
 

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverIT.java
@@ -31,7 +31,7 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
-public class CaseUpdatedReceiverIT {
+public class CaseReceiverIT {
   private static final String CASE_UPDATE_ROUTING_KEY = "event.case.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
   private static final String TEST_CASE_ID = "test_case_id";

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
@@ -19,14 +19,14 @@ import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtActionInstruction;
 import uk.gov.ons.census.fwmtadapter.model.dto.fwmt.FwmtCancelActionInstruction;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CaseUpdatedReceiverTest {
+public class CaseReceiverTest {
 
   @Mock private RabbitTemplate rabbitTemplate;
 
   @Value("${queueconfig.outbound-exchange}")
   private String outboundExchange;
 
-  @InjectMocks private CaseUpdatedReceiver underTest;
+  @InjectMocks private CaseReceiver underTest;
 
   @Test
   public void testReceiveCancelDecision() {


### PR DESCRIPTION
# Motivation and Context
Rename a receiver whose name had become stale

# What has changed
Renamed CaseUpdated to CaseReceiver Channel

# How to test?
test it and as part of this ticket with the ATs, should also work with Master

# Links
https://trello.com/c/9WC8hFnx/706-am1-part-3-new-address-notify-field-5