### PR TITLE
Add createdDateTime and lastUpdated fields

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
@@ -17,6 +17,8 @@ public class CollectionCase {
   private OffsetDateTime actionableFrom;
   private Boolean receiptReceived;
   private String refusalReceived;
+  private OffsetDateTime createdDateTime;
+  private OffsetDateTime lastUpdated;
 
   // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RH
   private String actionPlanId;


### PR DESCRIPTION
# Motivation and Context
New fields in CASE_UPDATED and CASE_CREATED events

# What has changed
New fields added

# How to test?
Build other repos on card and run ATs

# Links
https://trello.com/c/n6FwePKv/1052-waiting-on-action-processor-casecreated-caseupdated-events-should-contain-the-createddatetime-field-5

https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Response+Management+Event+Dictionary