### PR TITLE
Use UUID data type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
@@ -3,16 +3,17 @@ package uk.gov.ons.census.fwmtadapter.model.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 @JsonInclude(Include.NON_NULL)
 public class CollectionCase {
-  private String id;
+  private UUID id;
   private String caseRef;
   private String caseType;
   private String survey;
-  private String collectionExerciseId;
+  private UUID collectionExerciseId;
   private Address address;
   private OffsetDateTime actionableFrom;
   private Boolean receiptReceived;
@@ -21,7 +22,7 @@ public class CollectionCase {
   private OffsetDateTime lastUpdated;
 
   // Below this line is extra data potentially needed by Action Scheduler - can be ignored by RH
-  private String actionPlanId;
+  private UUID actionPlanId;
   private String treatmentCode;
   private String oa;
   private String lsoa;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmtadapter.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -8,5 +9,5 @@ public class Event {
   private String source;
   private String channel;
   private String dateTime;
-  private String transactionId;
+  private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmtadapter.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -18,7 +19,7 @@ public class FieldworkFollowup {
   private String longitude;
   private String actionPlan;
   private String actionType;
-  private String caseId;
+  private UUID caseId;
   private String caseRef;
   private String addressType;
   private String addressLevel;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.fwmtadapter.model.dto.fwmt;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -9,7 +10,7 @@ public class FwmtActionInstruction {
   private String surveyName;
   private String addressType;
   private String addressLevel;
-  private String caseId;
+  private UUID caseId;
   private String caseRef;
   private String estabType;
   private String fieldOfficerId;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmtadapter.model.dto.fwmt;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -8,7 +9,7 @@ public class FwmtCancelActionInstruction {
   private String surveyName;
   private String addressType;
   private String addressLevel;
-  private String caseId;
+  private UUID caseId;
   private Integer ceExpectedCapacity;
   private Integer ceActualResponses;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import uk.gov.ons.census.fwmtadapter.util.RabbitQueueHelper;
 public class CaseReceiverIT {
   private static final String CASE_UPDATE_ROUTING_KEY = "event.case.update";
   private static final String ADAPTER_OUTBOUND_QUEUE = "RM.Field";
-  private static final String TEST_CASE_ID = "test_case_id";
+  private static final UUID TEST_CASE_ID = UUID.randomUUID();
   private static final String TEST_CASE_REF = "test_case_ref";
   private static final String TEST_SURVEY = "test_survey";
   private static final String TEST_ADDRESS_TYPE = "test_address_type";

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -28,11 +29,13 @@ public class CaseReceiverTest {
 
   @InjectMocks private CaseReceiver underTest;
 
+  private UUID TEST_CASE_ID = UUID.randomUUID();
+
   @Test
   public void testReceiveCancelDecision() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setSurvey("CENSUS");
     Address address = new Address();
     address.setAddressLevel("U");
@@ -57,7 +60,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtCancelActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtCancelActionInstruction actualAi = aiArgumentCaptor.getValue();
-    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualAi.getSurveyName()).isEqualTo("CENSUS");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
@@ -68,7 +71,7 @@ public class CaseReceiverTest {
   public void testReceiveCreateDecision() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("HH");
     Address address = new Address();
@@ -96,7 +99,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtActionInstruction actualActionInstruction = aiArgumentCaptor.getValue();
-    assertThat(actualActionInstruction.getCaseId()).isEqualTo("testId");
+    assertThat(actualActionInstruction.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualActionInstruction.getCaseRef()).isEqualTo("testRef");
     assertThat(actualActionInstruction.getAddressType()).isEqualTo("test address type");
     assertThat(actualActionInstruction.getAddressLevel()).isEqualTo("U");
@@ -112,7 +115,7 @@ public class CaseReceiverTest {
   public void testReceiveCreateDecisionCE() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("CE");
 
@@ -142,7 +145,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtActionInstruction actualAi = aiArgumentCaptor.getValue();
-    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("E");
@@ -155,7 +158,7 @@ public class CaseReceiverTest {
   public void testReceiveUpdateDecision() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("HH");
     Address address = new Address();
@@ -181,7 +184,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtActionInstruction actualAi = aiArgumentCaptor.getValue();
-    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
@@ -193,7 +196,7 @@ public class CaseReceiverTest {
   public void testReceiveUpdateDecisionCE() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("CE");
 
@@ -223,7 +226,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtActionInstruction actualAi = aiArgumentCaptor.getValue();
-    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("E");
@@ -236,7 +239,7 @@ public class CaseReceiverTest {
   public void testReceiveUpdateDecisionSPG() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("SPG");
 
@@ -266,7 +269,7 @@ public class CaseReceiverTest {
         ArgumentCaptor.forClass(FwmtActionInstruction.class);
     verify(rabbitTemplate).convertAndSend(eq(outboundExchange), eq(""), aiArgumentCaptor.capture());
     FwmtActionInstruction actualAi = aiArgumentCaptor.getValue();
-    assertThat(actualAi.getCaseId()).isEqualTo("testId");
+    assertThat(actualAi.getCaseId()).isEqualTo(TEST_CASE_ID);
     assertThat(actualAi.getCaseRef()).isEqualTo("testRef");
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
@@ -279,7 +282,7 @@ public class CaseReceiverTest {
   public void testReceiveUpdateDecisionWithBlankQuestionnaireReturned() {
     // Given
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId("testId");
+    collectionCase.setId(TEST_CASE_ID);
     collectionCase.setCaseRef("testRef");
     collectionCase.setCaseType("HH");
     Address address = new Address();


### PR DESCRIPTION
# Motivation and Context
Now using the UUID data type for UUID data.

# What has changed
Changes to a few DTOs and tests

# How to test?
Build it and run it against the acceptance tests (master), with use-UUID-type-for-UUID-data branches of DDL, case-processor, case-api, action-scheduler, action-worker, action-processor and notify-processor

# Links
https://trello.com/c/r9qwqhaS