### PR TITLE
Hack around the problem with retry messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
@@ -33,9 +33,6 @@ public class MessageConsumerConfig {
   @Value("${queueconfig.consumers}")
   private int consumers;
 
-  @Value("${queueconfig.retry-attempts}")
-  private int retryAttempts;
-
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
 
@@ -98,9 +95,12 @@ public class MessageConsumerConfig {
             "Fieldwork Adapter",
             queueName);
 
+    // The retries don't seem to respect the transactions and we can end up with a messed up
+    // state involving Rabbit messages being emitted but DB changes not being committed.
+    // A single retry seems to work, but more than that is problematic.
     RetryOperationsInterceptor retryOperationsInterceptor =
         RetryInterceptorBuilder.stateless()
-            .maxAttempts(retryAttempts)
+            .maxAttempts(1) // DO NOT INCREASE TO MORE THAN 1 - NASTY SPRING BUG
             .backOffPolicy(fixedBackOffPolicy)
             .recoverer(managedMessageRecoverer)
             .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ queueconfig:
   outbound-exchange: adapter-outbound-exchange
   case-updated-queue: FieldworkAdapter.caseUpdated
   consumers: 50
-  retry-attempts: 3
+  retry-attempts: 1
   retry-delay: 1000 #milliseconds
 
 healthcheck:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,6 @@ queueconfig:
   outbound-exchange: adapter-outbound-exchange
   case-updated-queue: FieldworkAdapter.caseUpdated
   consumers: 50
-  retry-attempts: 1
   retry-delay: 1000 #milliseconds
 
 healthcheck:


### PR DESCRIPTION
# Motivation and Context
We saw a problem with Case Processor processing a Rabbit message more than once. This seemed to be due to the Spring retry code, but we can't be certain.

# What has changed
Reduced retry count to 1 for failed rabbit messages.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/SCSNxVxU