### PR TITLE
Fix Spring retries bug with transaction manager

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
@@ -13,10 +13,12 @@ import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -43,6 +45,11 @@ public class AppConfig {
     rabbitTemplate.setMessageConverter(messageConverter);
     rabbitTemplate.setChannelTransacted(true);
     return rabbitTemplate;
+  }
+
+  @Bean
+  PlatformTransactionManager transactionManager(ConnectionFactory connectionFactory) {
+    return new RabbitTransactionManager(connectionFactory);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
@@ -13,12 +13,10 @@ import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -45,11 +43,6 @@ public class AppConfig {
     rabbitTemplate.setMessageConverter(messageConverter);
     rabbitTemplate.setChannelTransacted(true);
     return rabbitTemplate;
-  }
-
-  @Bean
-  public PlatformTransactionManager transactionManager(ConnectionFactory connectionFactory) {
-    return new RabbitTransactionManager(connectionFactory);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/AppConfig.java
@@ -13,10 +13,12 @@ import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -43,6 +45,11 @@ public class AppConfig {
     rabbitTemplate.setMessageConverter(messageConverter);
     rabbitTemplate.setChannelTransacted(true);
     return rabbitTemplate;
+  }
+
+  @Bean
+  public PlatformTransactionManager transactionManager(ConnectionFactory connectionFactory) {
+    return new RabbitTransactionManager(connectionFactory);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
@@ -17,7 +17,6 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
-import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.ons.census.fwmtadapter.client.ExceptionManagerClient;
 import uk.gov.ons.census.fwmtadapter.messaging.ManagedMessageRecoverer;
 import uk.gov.ons.census.fwmtadapter.model.dto.FieldworkFollowup;
@@ -27,7 +26,6 @@ import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 public class MessageConsumerConfig {
   private final ExceptionManagerClient exceptionManagerClient;
   private final ConnectionFactory connectionFactory;
-  private final PlatformTransactionManager transactionManager;
 
   @Value("${messagelogging.logstacktraces}")
   private boolean logStackTraces;
@@ -48,12 +46,9 @@ public class MessageConsumerConfig {
   private String caseUpdatedQueue;
 
   public MessageConsumerConfig(
-      ExceptionManagerClient exceptionManagerClient,
-      ConnectionFactory connectionFactory,
-      PlatformTransactionManager transactionManager) {
+      ExceptionManagerClient exceptionManagerClient, ConnectionFactory connectionFactory) {
     this.exceptionManagerClient = exceptionManagerClient;
     this.connectionFactory = connectionFactory;
-    this.transactionManager = transactionManager;
   }
 
   @Bean
@@ -114,8 +109,6 @@ public class MessageConsumerConfig {
         new SimpleMessageListenerContainer(connectionFactory);
     container.setQueueNames(queueName);
     container.setConcurrentConsumers(consumers);
-    container.setChannelTransacted(true);
-    container.setTransactionManager(transactionManager);
     container.setAdviceChain(retryOperationsInterceptor);
     return container;
   }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/config/MessageConsumerConfig.java
@@ -17,6 +17,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.ons.census.fwmtadapter.client.ExceptionManagerClient;
 import uk.gov.ons.census.fwmtadapter.messaging.ManagedMessageRecoverer;
 import uk.gov.ons.census.fwmtadapter.model.dto.FieldworkFollowup;
@@ -26,12 +27,16 @@ import uk.gov.ons.census.fwmtadapter.model.dto.ResponseManagementEvent;
 public class MessageConsumerConfig {
   private final ExceptionManagerClient exceptionManagerClient;
   private final ConnectionFactory connectionFactory;
+  private final PlatformTransactionManager transactionManager;
 
   @Value("${messagelogging.logstacktraces}")
   private boolean logStackTraces;
 
   @Value("${queueconfig.consumers}")
   private int consumers;
+
+  @Value("${queueconfig.retry-attempts}")
+  private int retryAttempts;
 
   @Value("${queueconfig.retry-delay}")
   private int retryDelay;
@@ -43,9 +48,12 @@ public class MessageConsumerConfig {
   private String caseUpdatedQueue;
 
   public MessageConsumerConfig(
-      ExceptionManagerClient exceptionManagerClient, ConnectionFactory connectionFactory) {
+      ExceptionManagerClient exceptionManagerClient,
+      ConnectionFactory connectionFactory,
+      PlatformTransactionManager transactionManager) {
     this.exceptionManagerClient = exceptionManagerClient;
     this.connectionFactory = connectionFactory;
+    this.transactionManager = transactionManager;
   }
 
   @Bean
@@ -95,12 +103,9 @@ public class MessageConsumerConfig {
             "Fieldwork Adapter",
             queueName);
 
-    // The retries don't seem to respect the transactions and we can end up with a messed up
-    // state involving Rabbit messages being emitted but DB changes not being committed.
-    // A single retry seems to work, but more than that is problematic.
     RetryOperationsInterceptor retryOperationsInterceptor =
         RetryInterceptorBuilder.stateless()
-            .maxAttempts(2) // DO NOT INCREASE TO MORE THAN 2 - NASTY SPRING BUG
+            .maxAttempts(retryAttempts)
             .backOffPolicy(fixedBackOffPolicy)
             .recoverer(managedMessageRecoverer)
             .build();
@@ -110,7 +115,7 @@ public class MessageConsumerConfig {
     container.setQueueNames(queueName);
     container.setConcurrentConsumers(consumers);
     container.setChannelTransacted(true);
-
+    container.setTransactionManager(transactionManager);
     container.setAdviceChain(retryOperationsInterceptor);
     return container;
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,8 @@ queueconfig:
   outbound-exchange: adapter-outbound-exchange
   case-updated-queue: FieldworkAdapter.caseUpdated
   consumers: 50
-  retry-delay: 3000 #milliseconds
+  retry-attempts: 3
+  retry-delay: 1000 #milliseconds
 
 healthcheck:
   frequency: 1000 #milliseconds


### PR DESCRIPTION
# Motivation and Context
If we hit a problem when processing a Rabbit message, we aren't rolling back and handling retries properly - we are sending extra (duplicate) Rabbit messages, amongst other problems. This is quite fundamental to the reliable functioning of RM, so we can trust our code not to corrupt any data in the event of exceptions.

# What has changed
Added a `ChainedTransactionManager` per the suggestion of Dr David Syer in his article _Distributed transactions in Spring, with and without XA_ (http://www.infoworld.com/article/2077963/distributed-transactions-in-spring--with-and-without-xa.html)

# How to test?
It's super hard.

Suggestion: set the cache fetch count to 3,000 or more, and the timeout to 5 seconds or less, then run the AT scenario `Tranche 2 household case details to be sent to the Field Work Management Tool` with a freshly booted up Case Processor - you would see duplicate cases being emitted, erroneously, in the original code.

# Links
Trello: https://trello.com/c/J4uL5FRY