### PR TITLE
Consume Secure Flag On New Address Reported

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiver.java
@@ -55,7 +55,7 @@ public class ActionFieldReceiver {
     actionInstruction.setUprn(followup.getUprn());
     actionInstruction.setEstabUprn(followup.getEstabUprn());
 
-    if (followup.getMetadata() != null) {
+    if (followup.getMetadata() != null && followup.getMetadata().getSecureEstablishment() != null) {
       actionInstruction.setSecureEstablishment(followup.getMetadata().getSecureEstablishment());
     }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiver.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiver.java
@@ -95,7 +95,7 @@ public class CaseReceiver {
       actionInstruction.setUndeliveredAsAddress(true);
     }
 
-    if (caze.getMetadata() != null) {
+    if (caze.getMetadata() != null && caze.getMetadata().getSecureEstablishment() != null) {
       actionInstruction.setSecureEstablishment(caze.getMetadata().getSecureEstablishment());
     }
 

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.fwmtadapter.model.dto.fwmt;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.UUID;
 import lombok.Data;
 
@@ -33,6 +32,5 @@ public class FwmtActionInstruction {
   private Boolean undeliveredAsAddress;
   private Boolean blankFormReturned;
 
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  private Boolean secureEstablishment;
+  private boolean secureEstablishment;
 }

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -31,6 +31,5 @@ public class FwmtActionInstruction {
   private Integer ceActualResponses;
   private Boolean undeliveredAsAddress;
   private Boolean blankFormReturned;
-
   private boolean secureEstablishment;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
@@ -152,6 +152,6 @@ public class ActionFieldReceiverTest {
         .convertAndSend(eq("TEST EXCHANGE"), eq(""), actionInstructionArgumentCaptor.capture());
     FwmtActionInstruction actionRequest = actionInstructionArgumentCaptor.getValue();
 
-    assertThat(actionRequest.getSecureEstablishment()).isTrue();
+    assertThat(actionRequest.isSecureEstablishment()).isTrue();
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/CaseReceiverTest.java
@@ -105,7 +105,7 @@ public class CaseReceiverTest {
     assertThat(actualActionInstruction.getAddressLevel()).isEqualTo("U");
     assertThat(actualActionInstruction.getActionInstruction())
         .isEqualTo(ActionInstructionType.CREATE);
-    assertThat(actualActionInstruction.getSecureEstablishment()).isNull();
+    assertThat(actualActionInstruction.isSecureEstablishment()).isFalse();
     assertThat(actualActionInstruction.getBlankFormReturned()).isNull();
     assertThat(actualActionInstruction.getUprn()).isEqualTo("U1");
     assertThat(actualActionInstruction.getEstabUprn()).isEqualTo("EstabU2");
@@ -151,7 +151,7 @@ public class CaseReceiverTest {
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("E");
     assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.CREATE);
-    assertThat(actualAi.getSecureEstablishment()).isTrue();
+    assertThat(actualAi.isSecureEstablishment()).isTrue();
     assertThat(actualAi.getBlankFormReturned()).isNull();
   }
 
@@ -232,7 +232,7 @@ public class CaseReceiverTest {
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("E");
     assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(actualAi.getSecureEstablishment()).isFalse();
+    assertThat(actualAi.isSecureEstablishment()).isFalse();
     assertThat(actualAi.getBlankFormReturned()).isNull();
   }
 
@@ -275,7 +275,7 @@ public class CaseReceiverTest {
     assertThat(actualAi.getAddressType()).isEqualTo("test address type");
     assertThat(actualAi.getAddressLevel()).isEqualTo("U");
     assertThat(actualAi.getActionInstruction()).isEqualTo(ActionInstructionType.UPDATE);
-    assertThat(actualAi.getSecureEstablishment()).isTrue();
+    assertThat(actualAi.isSecureEstablishment()).isTrue();
     assertThat(actualAi.getBlankFormReturned()).isNull();
   }
 
@@ -318,7 +318,7 @@ public class CaseReceiverTest {
     assertThat(actualActionInstruction.getAddressLevel()).isEqualTo("U");
     assertThat(actualActionInstruction.getActionInstruction())
         .isEqualTo(ActionInstructionType.CREATE);
-    assertThat(actualActionInstruction.getSecureEstablishment()).isNull();
+    assertThat(actualActionInstruction.isSecureEstablishment()).isFalse();
     assertThat(actualActionInstruction.getBlankFormReturned()).isNull();
     assertThat(actualActionInstruction.getUprn()).isEqualTo("U1");
     assertThat(actualActionInstruction.getEstabUprn()).isEqualTo("EstabU2");


### PR DESCRIPTION
# Motivation and Context
We want to record a property as secure so that future visits can be arranged if required

# What has changed
secureEstablishment flag changed from object to primitive type so it cannot be null
Updated tests

# How to test?
Build with other branches on card and run ATs

# Links
https://trello.com/c/4fnNI9lZ/1231-consume-secure-flag-on-newaddressreported-5
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=40216113