### PR TITLE
AddressTypeChange for CE Case ceActualResponses Defaulted to Zero

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/CollectionCase.java
@@ -33,7 +33,7 @@ public class CollectionCase {
   private String fieldCoordinatorId;
   private String fieldOfficerId;
   private Integer ceExpectedCapacity;
-  private Integer ceActualResponses;
+  private int ceActualResponses;
   private Boolean addressInvalid;
   private boolean handDelivery;
   private CaseMetadata metadata;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/FieldworkFollowup.java
@@ -27,7 +27,7 @@ public class FieldworkFollowup {
   private String fieldOfficerId;
   private String fieldCoordinatorId;
   private Integer ceExpectedCapacity;
-  private Integer ceActualResponses;
+  private int ceActualResponses;
   private String surveyName;
   private Boolean blankQreReturned;
   private Boolean receipted;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtActionInstruction.java
@@ -28,7 +28,7 @@ public class FwmtActionInstruction {
   private boolean ce1Complete;
   private boolean handDeliver;
   private Integer ceExpectedCapacity;
-  private Integer ceActualResponses;
+  private int ceActualResponses;
   private Boolean undeliveredAsAddress;
   private Boolean blankFormReturned;
   private boolean secureEstablishment;

--- a/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
+++ b/src/main/java/uk/gov/ons/census/fwmtadapter/model/dto/fwmt/FwmtCancelActionInstruction.java
@@ -11,5 +11,5 @@ public class FwmtCancelActionInstruction {
   private String addressLevel;
   private UUID caseId;
   private Integer ceExpectedCapacity;
-  private Integer ceActualResponses;
+  private int ceActualResponses;
 }

--- a/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmtadapter/messaging/ActionFieldReceiverTest.java
@@ -28,7 +28,7 @@ public class ActionFieldReceiverTest {
     fieldworkFollowup.setSurveyName("CENSUS");
     fieldworkFollowup.setBlankQreReturned(false);
     fieldworkFollowup.setAddressType("HH");
-    fieldworkFollowup.setCeActualResponses(null);
+    fieldworkFollowup.setCeActualResponses(0);
     fieldworkFollowup.setCeExpectedCapacity(null);
     fieldworkFollowup.setHandDelivery(true);
 
@@ -70,7 +70,7 @@ public class ActionFieldReceiverTest {
 
     assertThat(actionInstruction.isCe1Complete()).isFalse();
     assertThat(actionInstruction.getCeExpectedCapacity()).isNull();
-    assertThat(actionInstruction.getCeActualResponses()).isNull();
+    assertThat(actionInstruction.getCeActualResponses()).isEqualTo(0);
     assertThat(actionInstruction.isHandDeliver()).isTrue();
   }
 


### PR DESCRIPTION
# Motivation and Context
When an AddressTypeChange event occurs where the new address is a CE Case, the ceActualResponses is null rather than 0 

# What has changed
Changed ceActualResponses from Integer to int so now defaults to 0 instead of null
Updated test

# How to test?
Maven clean install on branch and check image builds and tests pass

# Links
https://trello.com/c/DUgevj8y